### PR TITLE
fix: remove css with `:has` as that breaks safari 15.4 and above

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -51,10 +51,6 @@ html[data-theme='dark'] {
     padding: 0 var(--ifm-pre-padding);
 }
 
-:not(br:has(.Terminal-prompt)) {
-    color: green;
-}
-
 was-this-helpful {
     --was-this-helpful-main-color: rgb(28, 30, 33);
     --was-this-helpful-font-family: 'Inter', sans-serif;


### PR DESCRIPTION
Before on Safari 15.4
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/9247442/159793546-fa4f98f2-dc92-461b-bbaa-1b96916500e5.png">

After on Safari 15.4
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/9247442/159793589-86ccf086-4961-410d-bb95-99a1ba982dbd.png">

Cause:
https://caniuse.com/?search=has
