### PR TITLE
fix typo in pipeline configs example

### DIFF
--- a/docs/configuration/pipeline-configuration-files.mdx
+++ b/docs/configuration/pipeline-configuration-files.mdx
@@ -20,7 +20,7 @@ If you have your YAML files in a different directory, or want to provision only 
 the CLI flag `pipelines.path` and point to your file or directory:
 
 ```shell
-./conduit -pipeline.path ../my-directory
+./conduit -pipelines.path ../my-directory
 ```
 
 If your directory does not exist, Conduit will fail with an error: `"pipelines.path" config value is invalid`


### PR DESCRIPTION
The CLI command for using config files is missing an 's'.