### PR TITLE
Conduit 0.6.0

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -28,7 +28,7 @@ To get started:
 If you're on Mac, it will look something like this:
 
 ```shell
-tar zxvf conduit_0.5.2_Darwin_x86_64.tar.gz
+tar zxvf conduit_0.6.0_Darwin_x86_64.tar.gz
 ```
 
 3. Start Conduit:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -115,7 +115,7 @@ module.exports = {
       content: `
         <div class='wrapper announcement-banner'>
           <p class='content'>
-            Conduit 0.5 is here!&nbsp;
+            Conduit 0.6 is here!&nbsp;
             <a class='cta' href='https://github.com/ConduitIO/conduit/releases/latest' target='_blank' rel='noreferrer noopener'>See what's new</a>&nbsp;
           </p>
         </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -89,7 +89,7 @@ export default function Home() {
       <div className='announcement-banner bg-orange-kj'>
         <Wrapper>
           <p className='content'>
-            Conduit 0.5 is here!&nbsp;
+            Conduit 0.6 is here!&nbsp;
             <a className='cta' href='https://github.com/ConduitIO/conduit/releases/latest' target='_blank' rel='noreferrer noopener'>See what's new</a>.
           </p>
 


### PR DESCRIPTION
Same as https://github.com/ConduitIO/conduit-site/pull/26 for the 0.6 release.