### PR TITLE
doc(processors): How to use standalone processors

### DIFF
--- a/docs/introduction/what-is-conduit.mdx
+++ b/docs/introduction/what-is-conduit.mdx
@@ -9,10 +9,10 @@ user experience for building and running real-time data pipelines.
 
 Out of the box, Conduit comes with:
 
-- a UI
-- common connectors 
-- processors
-- observability
+- A UI
+- Common connectors 
+- Processors
+- Observability
 
 The batteries are included 🔋
 

--- a/docs/processors/getting-started.mdx
+++ b/docs/processors/getting-started.mdx
@@ -27,11 +27,11 @@ attached to a single parent, which can be either a connector or a pipeline:
 When it comes to using a processor, Conduit supports different types:
 
 - [Built-in processors](/docs/processors/builtin) will perform the most common operations you could expect such as filtering fields, replacing fields, posting payloads to a HTTP endpoint, etc. These are already coming as part of Conduit, and you can simply start using them with a bit of configuration. [Check out this document to see everything that's available](/docs/processors/builtin).
-- [Standalone processors](/docs/processors/standalone-processors) are the ones you could write yourself to do anything that's not already covered by the [Built-in](/docs/processors/builtin) ones. [Here's](/docs/processors/standalone-processors) more information about them.
+- [Standalone processors](/docs/processors/standalone are the ones you could write yourself to do anything that's not already covered by the [Built-in](/docs/processors/builtin) ones. [Here's](/docs/processors/standalone more information about them.
 
 ## How to use a processor
 
-In these following examples, we're using the [`json.decode`](/docs/processors/builtin/json.decode), but you could use any other you'd like from our [Built-in](/docs/processors/builtin/) ones, or even [reference](/docs/processors/referencing) your own [Standalone processor](/docs/processors/standalone-processors).
+In these following examples, we're using the [`json.decode`](/docs/processors/builtin/json.decode), but you could use any other you'd like from our [Built-in](/docs/processors/builtin/) ones, or even [reference](/docs/processors/referencing) your own [Standalone processor](/docs/processors/standalone.
 
 :::info
 

--- a/docs/processors/getting-started.mdx
+++ b/docs/processors/getting-started.mdx
@@ -27,11 +27,11 @@ attached to a single parent, which can be either a connector or a pipeline:
 When it comes to using a processor, Conduit supports different types:
 
 - [Built-in processors](/docs/processors/builtin) will perform the most common operations you could expect such as filtering fields, replacing fields, posting payloads to a HTTP endpoint, etc. These are already coming as part of Conduit, and you can simply start using them with a bit of configuration. [Check out this document to see everything that's available](/docs/processors/builtin).
-- [Standalone processors](/docs/processors/standalone are the ones you could write yourself to do anything that's not already covered by the [Built-in](/docs/processors/builtin) ones. [Here's](/docs/processors/standalone more information about them.
+- [Standalone processors](/docs/processors/standalone) are the ones you could write yourself to do anything that's not already covered by the [Built-in](/docs/processors/builtin) ones. [Here's](/docs/processors/standalone) more information about them.
 
 ## How to use a processor
 
-In these following examples, we're using the [`json.decode`](/docs/processors/builtin/json.decode), but you could use any other you'd like from our [Built-in](/docs/processors/builtin/) ones, or even [reference](/docs/processors/referencing) your own [Standalone processor](/docs/processors/standalone.
+In these following examples, we're using the [`json.decode`](/docs/processors/builtin/json.decode), but you could use any other you'd like from our [Built-in](/docs/processors/builtin/) ones, or even [reference](/docs/processors/referencing) your own [Standalone processor](/docs/processors/standalone).  
 
 :::info
 

--- a/docs/processors/referencing.mdx
+++ b/docs/processors/referencing.mdx
@@ -40,7 +40,6 @@ or API requests, is using the following format:
 
 :::info
 
-Read more about how to register
-[standalone processors](/docs/processors/standalone) in Conduit.
+Read more about how to register [standalone processors](/docs/processors/standalone) in Conduit.
 
 :::

--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 You can build your own Conduit Standalone Processors using the [Processor SDK](https://github.com/ConduitIO/conduit-processor-sdk).
 We currently only provide a Go SDK for processors. However, if you'd like to use another language for writing processor,
 feel free to [open an issue](https://github.com/ConduitIO/conduit/issues/new?assignees=&labels=feature%2Ctriage&projects=&template=1-feature-request.yml&title=Processor+SDK+%3A+%3Clanguage%3E)
-and request a specific language, or you can check [Standalone processors under the hood (WASM)](/docs/processors/how-it-works.mdx)
+and request a specific language, or you can check [Standalone processors under the hood (WASM)](/docs/processors/standalone/how-it-works.mdx)
 if you want to build your own.
 
 The [Processor SDK](https://github.com/ConduitIO/conduit-processor-sdk) exposes two ways of building processors, one for

--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 You can build your own Conduit Standalone Processors using the [Processor SDK](https://github.com/ConduitIO/conduit-processor-sdk).
 We currently only provide a Go SDK for processors. However, if you'd like to use another language for writing processor,
 feel free to [open an issue](https://github.com/ConduitIO/conduit/issues/new?assignees=&labels=feature%2Ctriage&projects=&template=1-feature-request.yml&title=Processor+SDK+%3A+%3Clanguage%3E)
-and request a specific language, or you can check [Standalone processors under the hood (WASM)](/docs/processors/standalone/how-it-works.mdx)
+and request a specific language, or you can check [Standalone processors under the hood (WASM)](/docs/processors/standalone/how-it-works)
 if you want to build your own.
 
 The [Processor SDK](https://github.com/ConduitIO/conduit-processor-sdk) exposes two ways of building processors, one for
@@ -295,7 +295,7 @@ GOARCH=wasm GOOS=wasip1 go build -o processor.wasm cmd/processor/main.go
 ````
 
 **_Congratulations!_** Now you have a new standalone processor.
-Check [Standalone processors](/docs/processors/standalone/index.mdx) for details on how to use your standalone
+Check [Standalone processors](/docs/processors/standalone/index) for details on how to use your standalone
 processor in a Conduit pipeline.
 
 :::note

--- a/docs/processors/standalone/how-it-works.mdx
+++ b/docs/processors/standalone/how-it-works.mdx
@@ -191,7 +191,7 @@ The last 100 numbers at the end of an `uin32` (between 4,294,967,195 and
 a number in this range it represents an error code and the plugin should stop
 running.
 
-Current error codes:
+**Current error codes:**
 
 - `4,294,967,294` - no more commands. Returned by `command_request` when Conduit
   has no more commands to return and the plugin should gracefully stop running

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -17,7 +17,7 @@ By default, standalone processors are expected to be found in a folder named `pr
 ```shell
 │ # Conduit binary
 ├── conduit
-│ # Folder with pipeline configurations
+│ # Folder with pipeline configurations (yaml files)
 ├── pipelines
 │ # Folder with standalone connectors (binary files)
 ├── connectors

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -89,8 +89,4 @@ If you end up writing a standalone processor you'd like to share with the commun
 
 - [Joining our Discord](https://discord.meroxa.com/)
 - [Posting a comment on GitHub Discussions](https://github.com/ConduitIO/conduit/discussions)
-<<<<<<< HEAD
 :::
-=======
-:::
->>>>>>> bad6cdd (apply feedback)

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -21,7 +21,7 @@ By default, standalone processors are expected to be found in a folder named `pr
 ├── pipelines
 │ # Folder with standalone connectors
 ├── connectors
-│ # Folder with standalone processors
+│ # Folder with standalone processors (wasm files)
 └── processors
 ```
 

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -67,7 +67,7 @@ GOARCH=wasm GOOS=wasip1 go build -o simple-processor.wasm main.go
 ## Using it in your pipeline
 
 
-As mentioned in our [Getting Started page](/docs/processors/getting-started), in order to use a processor in your pipeline, you need to update its configuration file [accordingly](/docs/processors/getting-started#how-to-use-a-processor) and [reference it](/docs/processors/referencing) accordingly:
+As mentioned in our [Getting Started page](/docs/processors/getting-started), in order to use a processor in your pipeline, you need to update its [configuration file](/docs/processors/getting-started#how-to-use-a-processor) and [reference it](/docs/processors/referencing) accordingly:
 
 
 ```yaml

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -12,7 +12,7 @@ Thanks to our [Web Assembly (Wasm) processor](/docs/processors/standalone/how-it
 
 ### Where to put them
 
-By default, standalone processors are expected to be found in a folder named `processors` alongside of your pipelines or [standalone connectors](/docs/connectors/getting-started.mdx):
+By default, standalone processors are expected to be found in a folder named `processors` alongside of your pipelines or [standalone connectors](/docs/connectors/getting-started):
 
 ```shell
 │ # Conduit binary

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -8,7 +8,7 @@ These are processors you'd write yourself in cases the [Built-in](/docs/processo
 
 ## How to write one
 
-Thanks to our [Web Assembly (Wasm) processor](/docs/processors/standalone/how-it-works) you can start writing processors in any language that can be compiled to Web Assembly. As a start, Conduit already provides a [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk) that will let you [write a processor](/docs/processors/standalone/building) in Golang.
+Thanks to our [Web Assembly (Wasm) processor](/docs/processors/standalone/how-it-works) you can start writing processors in any language that can be compiled to Web Assembly. As a start, Conduit already provides a [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk) that will let you [write a processor](/docs/processors/standalone/building) in Go.
 
 ### Where to put them
 
@@ -33,7 +33,7 @@ However, in case you need to reference processors in a different location, you c
 
 ### Using the [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk)
 
-Assuming you use our [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk), this is how a processor **plugin** written in Golang could look like. In the following example, we're going to be adding a `processed` field to each record processed by our pipeline:
+Assuming you use our [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk), this is how a processor **plugin** written in Go could look like. In the following example, we're going to be adding a `processed` field to each record processed by our pipeline:
 
 ```go
 //go:build wasm

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -19,7 +19,7 @@ By default, standalone processors are expected to be found in a folder named `pr
 ├── conduit
 │ # Folder with pipeline configurations
 ├── pipelines
-│ # Folder with standalone connectors
+│ # Folder with standalone connectors (binary files)
 ├── connectors
 │ # Folder with standalone processors (wasm files)
 └── processors

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -4,9 +4,89 @@ sidebar_position: 3
 
 # Standalone processors
 
-:::warning
+These are processors you'd write yourself in cases the [Built-in](/docs/processors/builtin/) ones don't meet your needs. 
 
-🚧 Page is under construction, content will be added soon.
-This page should include general info about how to use standalone processors.
+## How to write one
 
+Thanks to our [Web Assembly (Wasm) processor](/docs/processors/standalone/how-it-works) you can start writing processors in any language that can be compiled to Web Assembly. As a start, Conduit already provides a [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk) that will let you [write a processor](/docs/processors/standalone/building) in Golang.
+
+### Where to put them
+
+By default, standalone processors are expected to be found in a folder named `processors` alongside of your pipelines or [standalone connectors](/docs/connectors/getting-started.mdx):
+
+```shell
+│ # Conduit binary
+├── conduit
+│ # Folder with pipeline configurations
+├── pipelines
+│ # Folder with standalone connectors
+├── connectors
+│ # Folder with standalone processors
+└── processors
+```
+
+However, in case you need to reference processors in a different location, you could use the `-processors.path` flag when running Conduit:
+
+```
+./conduit -processors.path /my-custom-processors-path
+```
+
+### Using the [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk)
+
+Assuming you use our [conduit-processor-sdk](https://github.com/ConduitIO/conduit-processor-sdk), this is how a processor **plugin** written in Golang could look like. In the following example, we're going to be adding a `processed` field to each record processed by our pipeline:
+
+```go
+//go:build wasm
+
+package main
+
+import (
+    "context"
+
+    "github.com/conduitio/conduit-commons/opencdc"
+    sdk "github.com/conduitio/conduit-processor-sdk"
+)
+
+func main() {
+    sdk.Run(sdk.NewProcessorFunc(
+        sdk.Specification{Name: "simple-processor", Version: "v1.0.0"},
+        func(ctx context.Context, record opencdc.Record) (opencdc.Record, error) {
+            record.Payload.After.(opencdc.StructuredData)["processed"] = true
+            return record, nil
+        },
+    ))
+```
+
+After that, you'd need to compile it, and locate its `.wasm` file into the desired `processors` directory as previously mentioned:
+
+
+```shell
+GOARCH=wasm GOOS=wasip1 go build -o simple-processor.wasm main.go
+```
+
+## Using it in your pipeline
+
+
+As mentioned in our [Getting Started page](/docs/processors/getting-started), in order to use a processor in your pipeline, you need to update its configuration file [accordingly](/docs/processors/getting-started#how-to-use-a-processor) and [reference it](/docs/processors/referencing) accordingly:
+
+
+```yaml
+version: 2.2
+pipelines:
+  - id: example-pipeline
+    connectors:
+    # define source and destination connectors
+    # ...
+    processors:
+      - id: add-processed-field
+        plugin: standalone:simple-processor
+```
+
+When running your pipeline again, you should expect seeing a new `processed` field on every record processed.
+
+:::info
+If you end up writing a standalone processor you'd like to share with the community, please let us know! We'd love to hear from you by:  
+
+- [Joining our Discord](https://discord.meroxa.com/)
+- [Posting a comment on GitHub Discussions](https://github.com/ConduitIO/conduit/discussions)
 :::

--- a/docs/processors/standalone/index.mdx
+++ b/docs/processors/standalone/index.mdx
@@ -89,4 +89,8 @@ If you end up writing a standalone processor you'd like to share with the commun
 
 - [Joining our Discord](https://discord.meroxa.com/)
 - [Posting a comment on GitHub Discussions](https://github.com/ConduitIO/conduit/discussions)
+<<<<<<< HEAD
 :::
+=======
+:::
+>>>>>>> bad6cdd (apply feedback)


### PR DESCRIPTION
This pull-request adds a new index page for processors that should give users a quick overview on how to use standalone processors in Conduit.

Part of https://github.com/ConduitIO/conduit/issues/1422