### PR TITLE
fix: referenced standalone processor link is broken

### DIFF
--- a/docs/processors/referencing.mdx
+++ b/docs/processors/referencing.mdx
@@ -41,6 +41,6 @@ or API requests, is using the following format:
 :::info
 
 Read more about how to register
-[standalone processors](/docs/processors/standalone-processors) in Conduit.
+[standalone processors](/docs/processors/standalone) in Conduit.
 
 :::


### PR DESCRIPTION
## Description of issue
The following Informational admonition in the Conduit docs has a broken link:
> Read more about how to register [standalone processors](https://conduit.io/docs/processors/standalone-processors) in Conduit.

Link should be https://conduit.io/docs/processors/standalone or https://conduit.io/docs/processors/standalone/how-it-works