### PR TITLE
doc: include more examples

### DIFF
--- a/docs/pipeline-configuration-files/getting-started.mdx
+++ b/docs/pipeline-configuration-files/getting-started.mdx
@@ -9,7 +9,13 @@ provisioned by Conduit at startup. It's as simple as creating a YAML file that
 defines pipelines, connectors, processors, and their corresponding
 configurations.
 
-## Example pipeline (file to file)
+## Example pipeline
+
+:::tip
+
+In our [Conduit repository](https://github.com/ConduitIO/conduit), you can find [more examples](https://github.com/ConduitIO/conduit/tree/main/examples/pipelines), but to ilustrate a simple use case we'll show a pipeline using a file as a Source, and another file as a Destination.
+
+:::
 
 Create a folder called `pipelines` at the same level as your Conduit binary.
 Inside of that folder create a file named `file-to-file.yml`.


### PR DESCRIPTION
Includes a reference to the most recent [examples added]( https://github.com/ConduitIO/conduit/pull/1447). This way, we could simply add more examples to https://github.com/ConduitIO/conduit/tree/main/examples/pipelines and still find them from our docs for those who check out the code/docs in-distinctively.

