### PR TITLE
fix(guides): broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This app is built using [Docusaurus 3](https://docusaurus.io/).
 
 The Conduit Documentation contains:
 - Conduit Documentation
-- Conduit Guides
 
 ## Getting Started
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -74,7 +74,6 @@ const config: Config = {
       items: [
         { to: '/', label: 'Home', position: 'left', activeBaseRegex: `///` },
         { type: 'doc', docId: 'introduction/getting-started', position: 'left', label: 'Documentation' },
-        { to: '/guides', label: 'Guides', position: 'left' },
         { to: '/api', label: 'HTTP API', position: 'left' },
         { to: 'https://github.com/ConduitIO/conduit/discussions', label: 'GitHub Discussions', position: 'right' },
         { to: 'https://discord.meroxa.com', label: 'Discord Community', position: 'right' },


### PR DESCRIPTION
This page was removed in https://github.com/ConduitIO/conduit-site/pull/62. This PR removes the top link which currently sends shows a 404 page.