### PR TITLE
Record routing

### DIFF
--- a/docs/features/opencdc-record.mdx
+++ b/docs/features/opencdc-record.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'OpenCDC record'
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 An OpenCDC record in Conduit aims to standardize the format of data records exchanged between different connectors within a data processing pipeline. The primary objective is to ensure compatibility between various combinations of source and destination connectors.

--- a/docs/features/pipeline-semantics.mdx
+++ b/docs/features/pipeline-semantics.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pipeline Semantics"
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 This document describes the inner workings of a Conduit pipeline, its structure, and behavior. It also describes a

--- a/docs/features/record-routing.mdx
+++ b/docs/features/record-routing.mdx
@@ -18,15 +18,21 @@ Through this, a number of use cases are possible:
   multiple tables in each can be kept in sync with a single pipeline with only
   one source and one destination connector.
 * Route data from one collection (table, topic, index, etc.) to multiple
-  collections.
+  collections on a single server.
+* Route data to different instances or different systems altogether.
 
-## How does it work
+This can be done it two ways:
+
+* by using a connector that supports writing to multiple collections
+* by using filter processors
+
+## Using a connector that supports writing to multiple collections
 
 The [OpenCDC format](/docs/features/opencdc-record) recommends that a record's
 source or destination collection is written to its metadata using
 the [`opencdc.collection` key](/docs/features/opencdc-record#opencdccollection).
 
-Then, a destination connector can utilize that information and write the record
+A destination connector can then utilize that information and write the record
 to the correct collection.
 
 :::note
@@ -35,10 +41,12 @@ source collections, or write to multiple destination collections. Consult the
 connector documentation to check if it supports this feature.
 :::
 
-## Example
+### Example: Route data from multiple Kafka topics to multiple PostgreSQL tables on a single database server
 
 Let's assume we have a pipeline that streams data from two Kafka
-topics, `employees_finance` and `employees_legal` to PostgreSQL.
+topics, `employees_finance` and `employees_legal` to PostgreSQL (both of the
+connectors support reads from multiple collections and writes to multiple
+collections). A pipeline configuration file could look like this:
 
 ```yaml
 ---
@@ -66,7 +74,7 @@ pipelines:
           table: "employees"
 ```
 
-The Kafka connector will connectors like below:
+The Kafka connector will read records like the ones below:
 
 ```json lines
 {
@@ -96,9 +104,74 @@ The Kafka connector will connectors like below:
 ```
 
 The PostgreSQL destination connector will check the value in
-the `opencdc.collection` metadata field. Based on that will write John's
-information record to the `employees_finance` table and Adam's information to
+the `opencdc.collection` metadata field. Based on that, it will write John's
+information to the `employees_finance` table and Adam's information to
 the `employees_legal` table.
 
-If the `opencdc.collection` metadata field is missing, then the record will be
+If the `opencdc.collection` metadata field is missing, the record will then be
 written to the default table, which is `employees` in our case.
+
+## Using a `filter` processor with a condition
+
+In some cases, records from a single source collection need to be written to
+multiple connectors. Even if a destination connector can write to multiple
+collections, that feature sometimes cannot be used because the destinations have
+very different configurations. For example, the records may need to be written
+to different databases or different systems altogether.
+
+In scenarios like these, we can route records to multiple destination connectors
+using the built-in [`filter` processor](/docs/processors/builtin/filter) with
+a [condition](/docs/processors/conditions/).
+
+The advantage of this approach is that there will still be only one source,
+which means that we will read the data only once.
+
+### Example: Route data from a single Kafka topic to different PostgreSQL databases
+
+Let's assume we have a pipeline that reads employee data from a topic. The
+employees from the finance department (identified by `department: finance` in
+the metadata) need to be written to one PostgreSQL database. Employees from the
+legal department (identified by `department: legal` in the metadata) need to be
+written into a different database.
+
+```yaml
+---
+version: 2.2
+pipelines:
+  - id: example-pipeline
+    status: running
+    name: example-pipeline
+    description: 'Kafka to PostgreSQL'
+    connectors:
+      - id: kafka-source
+        type: source
+        plugin: "builtin:kafka"
+        name: kafka-source
+        settings:
+          servers: "localhost:9092"
+          topics: "employees_finance,employees_legal"
+
+      - id: finance
+        type: destination
+        plugin: "builtin:postgres"
+        name: finance
+        settings:
+          url: "postgresql://username:password@localhost/finance-db?sslmode=disable"
+          table: "employees"
+        processors:
+        - id: employees_finance_only
+          plugin: "filter"
+          condition: `{{index .Metadata "department" | eq "finance" | not}}`
+     
+      - id: legal
+        type: destination
+        plugin: "builtin:postgres"
+        name: legal
+        settings:
+          url: "postgresql://username:password@localhost/legal-db?sslmode=disable"
+          table: "employees"
+        processors:
+        - id: employees_legal_only
+          plugin: "filter"
+          condition: `{{index .Metadata "department" | eq "legal" | not}}`
+```

--- a/docs/features/record-routing.mdx
+++ b/docs/features/record-routing.mdx
@@ -1,0 +1,104 @@
+---
+title: 'Record routing'
+sidebar_position: 4
+keywords: [ 'synchronization', 'collections', 'routing' ]
+---
+
+## Overview
+
+Record routing in Conduit makes it easier to build one-to-many and many-to-many
+pipeline topologies. Or, in other words, it's possible to:
+
+* route data from one source to multiple collections in one destination
+* route data from multiple sources to multiple destinations.
+
+Through this, a number of use cases are possible:
+
+* Keep two instances synchronized. For examples, two database instances with
+  multiple tables in each can be kept in sync with a single pipeline with only
+  one source and one destination connector.
+* Route data from one collection (table, topic, index, etc.) to multiple
+  collections.
+
+## How does it work
+
+The [OpenCDC format](/docs/features/opencdc-record) recommends that a record's
+source or destination collection is written to its metadata using
+the [`opencdc.collection` key](/docs/features/opencdc-record#opencdccollection).
+
+Then, a destination connector can utilize that information and write the record
+to the correct collection.
+
+:::note
+It's the connectors that eventually provide the ability to read from multiple
+source collections, or write to multiple destination collections. Consult the
+connector documentation to check if it supports this feature.
+:::
+
+## Example
+
+Let's assume we have a pipeline that streams data from two Kafka
+topics, `employees_finance` and `employees_legal` to PostgreSQL.
+
+```yaml
+---
+version: 2.2
+pipelines:
+  - id: example-pipeline
+    status: running
+    name: example-pipeline
+    description: 'Kafka to PostgreSQL'
+    connectors:
+      - id: kafka-source
+        type: source
+        plugin: "builtin:kafka"
+        name: kafka-source
+        settings:
+          servers: "localhost:9092"
+          topics: "employees_finance,employees_legal"
+
+      - id: pg-destination
+        type: destination
+        plugin: "builtin:postgres"
+        name: pg-destination
+        settings:
+          url: "postgresql://username:password@localhost/testdb?sslmode=disable"
+          table: "employees"
+```
+
+The Kafka connector will connectors like below:
+
+```json lines
+{
+    "metadata": {
+        "opencdc.collection": "employees_finance",
+        // rest of metadata
+    },
+    "payload": {
+        "after": {
+            "name": "John"
+        }
+    }
+    // other record fields
+}
+{
+    "metadata": {
+        "opencdc.collection": "employees_legal",
+        // rest of metadata
+    },
+    "payload": {
+        "after": {
+            "name": "Adam"
+        }
+    }
+    // other record fields
+}
+```
+
+The PostgreSQL destination connector will check the value in
+the `opencdc.collection` metadata field. Based on that will write John's
+information record to the `employees_finance` table and Adam's information to
+the `employees_legal` table.
+
+If the `opencdc.collection` metadata field is missing, then the record will be
+written to the default table, which is `employees` in our case.

--- a/docs/features/stream-inspector.mdx
+++ b/docs/features/stream-inspector.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Stream Inspector'
-sidebar_position: 4
+sidebar_position: 6
 tag: ['Stream Inspector', 'Connector']
 keywords: ['stream', 'inspector']
 ---

--- a/docs/features/web-ui.mdx
+++ b/docs/features/web-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Web UI'
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 Conduit comes with a web UI that allows you to build a data pipeline using a


### PR DESCRIPTION
Closes https://github.com/ConduitIO/conduit/issues/1493.

As suggested in the issue, the page is named "Record routing". Routing the records with standard `opencdc.collection` metadata is possible in some scenarios, but in others, when we can use other features in Conduit.