### PR TITLE
Conduit release v0.10.0

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -32,7 +32,7 @@ To get started:
 If you're on Mac, it will look something like this:
 
 ```shell
-tar zxvf conduit_0.9.1_Darwin_x86_64.tar.gz
+tar zxvf conduit_0.10.0_Darwin_x86_64.tar.gz
 ```
 
 Depending on your operating system you may need to make the conduit binary executable.
@@ -56,7 +56,7 @@ Now that we have Conduit installed let's start it up to see what happens.
  `::::::::          ::::::::‘
       `::::        ::::‘
        `:::::....:::::‘
-         `::::::::::‘        Conduit v0.9.1 darwin/arm64
+         `::::::::::‘        Conduit v0.10.0 darwin/arm64
              ‘‘‘‘
 2024-02-21T14:41:26+00:00 INF All 0 tables opened in 0s component=badger.DB
 2024-02-21T14:41:26+00:00 INF Discard stats nextEmptySlot: 0 component=badger.DB
@@ -143,7 +143,7 @@ Conduit should start and we should see references to our new pipeline in the out
  `::::::::          ::::::::‘
       `::::        ::::‘
        `:::::....:::::‘
-         `::::::::::‘        Conduit v0.9.1 darwin/arm64
+         `::::::::::‘        Conduit v0.10.0 darwin/arm64
              ‘‘‘‘
 2024-02-21T16:50:35+00:00 INF All 0 tables opened in 0s component=badger.DB
 2024-02-21T16:50:35+00:00 INF Discard stats nextEmptySlot: 0 component=badger.DB

--- a/docs/running/binary.mdx
+++ b/docs/running/binary.mdx
@@ -12,10 +12,10 @@ The recommended way of running Conduit on a local machine is using a pre-built b
 ### Download
 First, download the [latest Conduit release](https://github.com/ConduitIO/conduit/releases/latest) for your platform.
 
-For an ARM based back Mac for example we'd grab the `conduit_0.9.1_Darwin_arm64.tar.gz` archive.
+For an ARM based back Mac for example we'd grab the `conduit_0.10.0_Darwin_arm64.tar.gz` archive.
 ### unzip the archive
 ```shell
-tar xzvf conduit_0.9.1_Darwin_arm64.tar.gz
+tar xzvf conduit_0.10.0_Darwin_arm64.tar.gz
 ```
 
 ### Run
@@ -34,7 +34,7 @@ In the directory in which you expanded the archive. Execute the Conduit binary:
  `::::::::          ::::::::‘
       `::::        ::::‘
        `:::::....:::::‘
-         `::::::::::‘        Conduit v0.9.1 linux/amd64
+         `::::::::::‘        Conduit v0.10.0 linux/amd64
              ‘‘‘‘
 2024-02-20T21:37:45+00:00 INF All 0 tables opened in 0s component=badger.DB
 2024-02-20T21:37:45+00:00 INF Discard stats nextEmptySlot: 0 component=badger.DB

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -130,8 +130,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Meroxa, Inc.`,
     },
     announcementBar: {
-      id: 'announcement-bar-2', // increment on change
-      content: `Conduit 0.9.1 is here! <a class='cta' href='https://github.com/ConduitIO/conduit/releases/latest' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
+      id: 'announcement-bar-3', // increment on change
+      content: `Conduit 0.10.0 is here! <a class='cta' href='https://github.com/ConduitIO/conduit/releases/latest' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
       isCloseable: true,
     },
     colorMode: {


### PR DESCRIPTION
Replaces `0.9.1` with `0.10.0`.