### PR TITLE
Customize Conduit's built-in connectors

### DIFF
--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Additional Built-in Plugins"
+title: "Add Built-in Connectors"
 sidebar_position: 2
 ---
 
-Built-in plugins offer better performance when compared to standalone plugins,
+Built-in connectors offer better performance when compared to standalone connectors,
 which is why in some cases it's desirable to have a custom build of Conduit that
-includes additional plugins.
+includes additional connectors.
 
 The simplest way to achieve so is to write a small application that embeds
-Conduit (i.e. uses Conduit as a library) and adds a plugin or plugins to its
+Conduit (i.e. uses Conduit as a library) and adds one or more connectors to its
 default configuration.
 
 In the example below we will add
@@ -39,10 +39,10 @@ import (
 )
 
 func main() {
-	// Get the default configuration, including all built-in plugins
+	// Get the default configuration, including all built-in connectors
 	cfg := conduit.DefaultConfig()
 
-	// Add the HTTP connector to list of built-in plugins
+	// Add the HTTP connector to list of built-in connectors
 	cfg.ConnectorPlugins["http"] = http.Connector
 
 	conduit.Serve(cfg)

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -3,9 +3,9 @@ title: "Add Built-in Connectors"
 sidebar_position: 2
 ---
 
-Built-in connectors offer better performance when compared to standalone connectors,
+Built-in connectors offer better performance when compared to standalone ones,
 which is why in some cases it's desirable to have a custom build of Conduit that
-includes additional connectors.
+includes additional built-in connectors.
 
 The simplest way to achieve so is to write a small application that embeds
 Conduit (i.e. uses Conduit as a library) and adds one or more connectors to its

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -25,7 +25,7 @@ go mod tidy
 ```
 
 Once that is done, we need to write a `main` function that:
-1. adds the HTTP connector the default Conduit configuration
+1. Adds the HTTP connector the default Conduit configuration
 2. runs Conduit with the custom configuration.
 
 That's done in the code below:

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -49,7 +49,7 @@ func main() {
 }
 ```
 
-The "custom Conduit" can be built with `go build main.go -o custom-conduit`. If
+This custom version of Conduit can be built with `go build main.go -o custom-conduit`. If
 you run the built binary, you can check that the HTTP connector has been
 included in the build by listing all the connector plugins: 
 ```shell

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -1,0 +1,70 @@
+---
+title: "Additional Built-in Plugins"
+sidebar_position: 2
+---
+
+Built-in plugins offer better performance when compared to standalone plugins,
+which is why in some cases it's desirable to have a custom build of Conduit that
+includes additional plugins.
+
+The simplest way to achieve so is to write a small application that embeds
+Conduit (i.e. uses Conduit as a library) and adds a plugin or plugins to its
+default configuration.
+
+In the example below we will add
+the [HTTP connector](https://github.com/conduitio-labs/conduit-connector-http)
+to Conduit as a built-in connector.
+
+First, we initialize a Go module with `go mod init github.com/conduitio-labs/custom-conduit`.
+
+Then , we need to add Conduit and the HTTP connector as dependencies:
+```shell
+go get github.com/conduitio/conduit
+go get github.com/conduitio-labs/conduit-connector-http
+go mod tidy
+```
+
+Once that is done, we need to write a `main` function that:
+1. adds the HTTP connector the default Conduit configuration
+2. runs Conduit with the custom configuration.
+
+That's done in the code below:
+
+```go
+package main
+
+import (
+	http "github.com/conduitio-labs/conduit-connector-http"
+	"github.com/conduitio/conduit/pkg/conduit"
+)
+
+func main() {
+	// Get the default configuration, including all built-in plugins
+	cfg := conduit.DefaultConfig()
+
+	// Add the HTTP connector to list of built-in plugins
+	cfg.ConnectorPlugins["http"] = http.Connector
+
+	conduit.Serve(cfg)
+}
+```
+
+The "custom Conduit" can be built with `go build main.go -o custom-conduit`. If
+you run the built binary, you can check that the HTTP connector has been
+included in the build by listing all the connector plugins: 
+```shell
+curl 'http://localhost:8080/v1/connectors/plugins'
+
+[
+  {
+    "name": "builtin:http@(devel)",
+    "summary": "HTTP source and destination connectors for Conduit.",
+    "description": "Conduit HTTP source and destination connectors, they connect to an HTTP URL and send HTTP requests.",
+    "version": "(devel)",
+    "author": "",
+    "destinationParams": {},
+    "sourceParams": {}
+  }
+  // other plugins
+]
+```

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Add Built-in Connectors"
+title: "Adding built-in Connectors"
 sidebar_position: 2
 ---
 

--- a/docs/connectors/additional-built-in-plugins.mdx
+++ b/docs/connectors/additional-built-in-plugins.mdx
@@ -26,7 +26,7 @@ go mod tidy
 
 Once that is done, we need to write a `main` function that:
 1. Adds the HTTP connector the default Conduit configuration
-2. runs Conduit with the custom configuration.
+2. Runs Conduit with the custom configuration.
 
 That's done in the code below:
 

--- a/docs/connectors/connector-lifecycle.mdx
+++ b/docs/connectors/connector-lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connector Lifecycle"
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 :::info

--- a/docs/connectors/kafka-connect-connector.mdx
+++ b/docs/connectors/kafka-connect-connector.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kafka Connect Connectors with Conduit"
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Using Kafka Connect Connectors with Conduit

--- a/docs/connectors/output-formats.mdx
+++ b/docs/connectors/output-formats.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Output Formats"
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 One of the challenges to be solved when integrating Conduit with other systems, such as Kafka Connect and Debezium, is


### PR DESCRIPTION
This PR adds instructions for adding built-in connectors to Conduit. Even though the approach taken is embedding Conduit into a simple app, the goal of this guide isn't to provide comprehensive instructions for embedding Conduit (which is planned in https://github.com/ConduitIO/conduit/issues/1268).