### PR TITLE
fix: broken link

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -265,6 +265,6 @@ Now that you've got the basics of running Conduit and creating a pipeline covere
 - [Connectors](/docs/connectors/getting-started)
 - [Pipelines](/docs/pipeline-configuration-files/getting-started)
 - [Processors](/docs/processors/getting-started)
-- [Conduit Architecture](/docs/introduction/architecture)
+- [Conduit Architecture](/docs/getting-started/architecture)
 
 ![scarf pixel conduit-site-docs-introduction](https://static.scarf.sh/a.png?x-pxid=01346572-0d57-4df3-8399-1425db913a0a)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -207,11 +207,14 @@ const config: Config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
-          // /docs/introduction/getting-started -> /docs
           {
             from: '/docs/introduction/getting-started',
             to: '/docs',
           },
+          {
+            from: '/docs/introduction/architecture',
+            to: '/docs/getting-started/architecture'
+          }
         ],
         createRedirects(existingPath) {
           if (existingPath.includes('/docs/running')) {


### PR DESCRIPTION
Architecture's page was moved on a previous PR and this link was outdated. Added a redirect just in case that was bookmarked.