### PR TITLE
add schema utility functions to building.mdx

### DIFF
--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -291,14 +291,14 @@ Check [Compiling the processor](#compiling-the-processor) for what to do next, a
 
 ## Schemas
 
-Processors have access to the Schemas in the used Schema Registry using two utility functions:
-1. `schema.Create` : You can use this utility function to create a new Schema and add it to the Schema Registry.
+Processors have access to the schemas in the used Schema Registry using two utility functions:
+1. `schema.Create` : You can use this utility function to create a new schema and add it to the Schema Registry.
 This function can be called in any of the main processor methods.
     
 **Example**:
 ```go
 func (p *setProcessor) Open(ctx context.Context) error {
-	// Add a new Schema to the Schema registry before starting to process the records.
+	// Add a new schema to the schema registry before starting to process the records.
 	schemaBytes := []byte(`{
           "name": "record",
           "type": "record",
@@ -322,7 +322,7 @@ func (p *setProcessor) Open(ctx context.Context) error {
 }
 ```
 
-2. `schema.Get`: You can use this utility function to get a Schema from the Schema Registry using
+2. `schema.Get`: You can use this utility function to get a schema from the Schema Registry using
   its `version` and `subject`. This function can be called in any of the main processor methods.
 
   **Example**:
@@ -330,18 +330,24 @@ func (p *setProcessor) Open(ctx context.Context) error {
 func (p *setProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {
 out := make([]sdk.ProcessedRecord, 0, len(records))
 for _, record := range records {
-    // get the schema subject name from the metadata
-    subject := rec.Metadata[opencdc.MetadataPayloadSchemaSubject]
-    // get the schema version from the metadata
-    version, err := strconv.Atoi(rec.Metadata[opencdc.MetadataPayloadSchemaVersion])
-    // get the schema 
-    get, err := schema.Get(ctx, subject, version)
-    // print the schema
-    fmt.Println(string(get.Bytes))
-    // rest of the code...
-    // ...
+		// get the schema subject name from the metadata
+		subject, err := rec.Metadata.GetPayloadSchemaSubject()
+		if err != nil {
+			return append(out, sdk.ErrorRecord{Error: err})
+		}
+		// get the schema version from the metadata
+		version, err := rec.Metadata.GetPayloadSchemaVersion()
+		if err != nil {
+			return append(out, sdk.ErrorRecord{Error: err})
+		}
+		// get the schema using the subject and the version
+		get, err := schema.Get(ctx, subject, version)
+		// print the schema
+		fmt.Println(string(get.Bytes))
+        // rest of the code...
+        // ...
 ```
-   Example output (the printed Schema):
+   Example output (the printed schema):
 ```json
 {
   "name": "record",

--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -289,6 +289,79 @@ func main() {
 
 Check [Compiling the processor](#compiling-the-processor) for what to do next, and how to compile the processor.
 
+## Schemas
+
+Processors have access to the Schemas in the used Schema Registry using two utility functions:
+1. `schema.Create` : You can use this utility function to create a new Schema and add it to the Schema Registry.
+This function can be called in any of the main processor methods.
+    
+**Example**:
+```go
+func (p *setProcessor) Open(ctx context.Context) error {
+	// Add a new Schema to the Schema registry before starting to process the records.
+	schemaBytes := []byte(`{
+          "name": "record",
+          "type": "record",
+          "fields": [
+            {
+              "name": "admin",
+              "type": "boolean"
+            },
+            {
+              "name": "id",
+              "type": "int"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        }`)
+	_, err := schema.Create(ctx, schema.TypeAvro, "subject1", schemaBytes)
+	return err
+}
+```
+
+2. `schema.Get`: You can use this utility function to get a Schema from the Schema Registry using
+  its `version` and `subject`. This function can be called in any of the main processor methods.
+
+  **Example**:
+```go
+func (p *setProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {
+out := make([]sdk.ProcessedRecord, 0, len(records))
+for _, record := range records {
+    // get the schema subject name from the metadata
+    subject := rec.Metadata[opencdc.MetadataPayloadSchemaSubject]
+    // get the schema version from the metadata
+    version, err := strconv.Atoi(rec.Metadata[opencdc.MetadataPayloadSchemaVersion])
+    // get the schema 
+    get, err := schema.Get(ctx, subject, version)
+    // print the schema
+    fmt.Println(string(get.Bytes))
+}
+```
+   Example output:
+```json
+{
+  "name": "record",
+  "type": "record",
+  "fields": [
+    {
+      "name": "admin",
+      "type": "boolean"
+    },
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}
+```
+
 ## Logging
 
 You can get a `zerolog.logger` instance from the context using the [`sdk.Logger`](https://pkg.go.dev/github.com/conduitio/conduit-processor-sdk#Logger)

--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -338,9 +338,10 @@ for _, record := range records {
     get, err := schema.Get(ctx, subject, version)
     // print the schema
     fmt.Println(string(get.Bytes))
-}
+    // rest of the code...
+    // ...
 ```
-   Example output:
+   Example output (the printed Schema):
 ```json
 {
   "name": "record",

--- a/docs/processors/standalone/building.mdx
+++ b/docs/processors/standalone/building.mdx
@@ -291,13 +291,50 @@ Check [Compiling the processor](#compiling-the-processor) for what to do next, a
 
 ## Schemas
 
-Processors have access to the schemas in the used Schema Registry using two utility functions:
+Processors have access to the schemas in the used Schema Registry. By default, if the pipeline uses a schema
+registry and the processor gets a record with the schema info in the `Metadata`, then the processor will have
+a middleware enabled. The middleware will decode the records before they are passed to the processor
+using their corresponding schema from the schema registry, and encode them again after the processing is done. To
+change this default behaviour, you can change these processor's configurations accordingly:
+- `sdk.schema.decode.key.enabled`: Whether to decode the record key using its corresponding schema from the schema registry.
+- `sdk.schema.decode.payload.enabled`: Whether to decode the record payload using its corresponding schema from the schema registry.
+- `sdk.schema.encode.key.enabled`: Whether to encode the record key using its corresponding schema from the schema registry.
+- `sdk.schema.encode.payload.enabled`: Whether to encode the record payload using its corresponding schema from the schema registry.
+
+**Example** of a piepline configuration file with these parameters:
+```yaml
+version: 2.2
+pipelines:
+  - id: test
+    status: running
+    connectors:
+      - id: employees-source
+        type: source
+        plugin: standalone:generator
+        settings:
+          rate: 1
+          collections.str.format.type: structured
+          collections.str.format.options.id: int
+          collections.str.format.options.name: string
+          collections.str.format.options.admin: bool
+          collections.str.operations: create
+      - id: logger-dest
+        type: destination
+        plugin: standalone:log
+    processors:
+      - id: access-schema
+        plugin: standalone:processor-simple
+        sdk.schema.decode.key.enabled: false # disabling the default behaviour
+        sdk.schema.encode.key.enabled: false # disabling the default behaviour
+```
+
+Processors can access the Schema Registry and the schemas using two utility functions:
 1. `schema.Create` : You can use this utility function to create a new schema and add it to the Schema Registry.
 This function can be called in any of the main processor methods.
     
 **Example**:
 ```go
-func (p *setProcessor) Open(ctx context.Context) error {
+func (p *exampleProcessor) Open(ctx context.Context) error {
 	// Add a new schema to the schema registry before starting to process the records.
 	schemaBytes := []byte(`{
           "name": "record",
@@ -327,7 +364,7 @@ func (p *setProcessor) Open(ctx context.Context) error {
 
   **Example**:
 ```go
-func (p *setProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {
+func (p *exampleProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {
 out := make([]sdk.ProcessedRecord, 0, len(records))
 for _, record := range records {
 		// get the schema subject name from the metadata


### PR DESCRIPTION
add docs for the Schemas access from processors, and the two Schema utility functions.