### PR TITLE
Clarify dead-letter queue behavior

### DIFF
--- a/docs/features/dead-letter-queue.mdx
+++ b/docs/features/dead-letter-queue.mdx
@@ -60,7 +60,8 @@ The first step is to change the window size and nack threshold:
 - If both the window size and the nack threshold are greater than 0, then nacked
   records will be sent to the dead-letter queue. Conduit will keep track of the
   number of nacks in the current window and stop the pipeline if the threshold
-  gets exceeded.
+  gets exceeded. Note that the window size needs to be greater than the nack
+  threshold, otherwise the threshold will never be reached.
 
 If the window settings are adjusted accordingly, then Conduit will route nacked
 records to the builtin log connector by default, causing nacked records to show

--- a/docs/features/dead-letter-queue.mdx
+++ b/docs/features/dead-letter-queue.mdx
@@ -49,7 +49,7 @@ By default, a Conduit pipeline will stop immediately when a record gets nacked.
 You can make the pipeline more fault-tolerant by enabling a dead-letter queue.
 The first step is to change the window size and nack threshold:
 
-- If the window size is greater than 1 and the nack threshold is 0, then the
+- If the window size is greater than 0 and the nack threshold is 0, then the
   first nacked record will cause the pipeline to stop running immediately. Such
   a configuration essentially disables the dead-letter queue. **This is the
   default configuration.**
@@ -57,10 +57,10 @@ The first step is to change the window size and nack threshold:
   records will be rerouted to the dead-letter queue without any limits. Such a
   configuration essentially disables the nack window and enables the dead-letter
   queue.
-- If the window size is greater than 1 and the nack threshold is greater than 0,
-  then nacked records will be sent to the dead-letter queue. Additionally,
-  Conduit will keep track of the number of nacks in the current window and stop
-  the pipeline if the threshold gets exceeded.
+- If both the window size and the nack threshold are greater than 0, then nacked
+  records will be sent to the dead-letter queue. Conduit will keep track of the
+  number of nacks in the current window and stop the pipeline if the threshold
+  gets exceeded.
 
 If the window settings are adjusted accordingly, then Conduit will route nacked
 records to the builtin log connector by default, causing nacked records to show


### PR DESCRIPTION
I corrected the numbers in the examples.