### PR TITLE
Link banner to changelog

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -170,7 +170,7 @@ const config: Config = {
     },
     announcementBar: {
       id: 'announcement-bar-5', // increment on change
-      content: `Conduit v0.12 is here! <a class='cta' href='https://github.com/ConduitIO/conduit/releases/latest' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
+      content: `Conduit v0.12 is here! <a class='cta' href='https://conduit.io/changelog/2024-10-10-conduit-0-12-0-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
       isCloseable: true,
     },
     colorMode: {


### PR DESCRIPTION
Now that we have a changelog we can link to it rather than to github.