### PR TITLE
Fix Broken Link on Connectors -> Getting Started

### DIFF
--- a/docs/1-using/4-connectors/0-getting-started.mdx
+++ b/docs/1-using/4-connectors/0-getting-started.mdx
@@ -33,6 +33,6 @@ Besides these connectors there is a number of standalone connectors that can be
 added to Conduit as plugins (find the complete
 list [here](/docs/using/connectors/list)).
 
-Have a look at how to [install a connector](/docs/using/connectors/installing next!
+Have a look at how to [install a connector](/docs/using/connectors/installing) next!
 
 ![scarf pixel conduit-site-docs-using-connectors](https://static.scarf.sh/a.png?x-pxid=53743422-c614-4e45-acaa-f1f9f604321e)


### PR DESCRIPTION
Small fix to the markdown on the connectors -> getting started page. The link for navigating to "Install A Connector" was broken as it was missing the closing parentheses.