### PR TITLE
Better schema docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 .env
 
 src/connectorgen/connectors.json
+
+.vscode

--- a/docs/1-using/6-other-features/1-schema-support.mdx
+++ b/docs/1-using/6-other-features/1-schema-support.mdx
@@ -46,6 +46,16 @@ Conduit's [Connector SDK](https://github.com/ConduitIO/conduit-connector-sdk) an
   schema extraction isn't enough and a schema needs to be built manually using
   the information from a source)
 
+When developing / testing your connector, the schemas will be created in memory
+by the sdk, so that you can simulate interacting with conduit without having to
+worry about starting up a conduit instance.
+When using [sdk.Serve](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#Serve)
+the connector will use the grpc API instead. The schema fetches are cached, but
+if by any chance you want to customize that behaviour you can override the
+[schema.Service](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#pkg-variables)
+variable.
+
+
 More information about how to work with schemas can be found in the relevant
 pages
 for [source connectors](/docs/developing/connectors/developing-source-connectors), [destination connectors](/docs/developing/connectors/developing-destination-connectors)

--- a/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
+++ b/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
@@ -218,3 +218,32 @@ func (s *Source) Teardown(context.Context) error {
 ```
 
 ![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)
+
+## Schema
+
+By default, the [sdk source middleware](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#SourceWithSchemaExtraction)
+will dynamically generate a schema for each record. While convenient, this is
+quite slow, as the middleware will try to create a schema for every single
+record.
+
+If the source connector is reading unstructured data, or you want to use your own
+schema extraction logic, you can disable the middleware like this:
+
+```go
+func NewSource() sdk.Source {
+	return sdk.SourceWithMiddleware(
+		&Source{},
+		sdk.DefaultSourceMiddleware(
+			sdk.SourceWithSchemaExtractionConfig{
+				PayloadEnabled: lang.Ptr(false),
+				KeyEnabled:     lang.Ptr(false),
+			},
+		)...,
+	)
+}
+```
+
+Otherwise you can use [schema.Create](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#Create)
+to manually handle the schema creation.
+
+An example implementation can be found in the [postgres connector](https://github.com/ConduitIO/conduit-connector-postgres).

--- a/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
+++ b/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
@@ -248,6 +248,7 @@ to manually handle the schema creation:
 ```go
 	import (
 		"github.com/conduitio/conduit-connector-sdk/schema"
+	    "github.com/conduitio/conduit-commons/schema/avro"
 		hambaavro "github.com/hamba/avro/v2"
 	)
 

--- a/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
+++ b/docs/2-developing/0-connectors/3-developing-source-connectors.mdx
@@ -65,15 +65,15 @@ overwriting the `sdk.SourceWithSchemaExtractionConfig` options:
 
 ```go
 sdk.SourceWithMiddleware(
-        &Source{},
-        sdk.DefaultSourceMiddleware(
-            // disable schema extraction by default, because the source produces raw data
-            sdk.SourceWithSchemaExtractionConfig{
-                PayloadEnabled: lang.Ptr(false),
-                KeyEnabled:     lang.Ptr(false),
-            },
-        )...,
-    )
+    &Source{},
+    sdk.DefaultSourceMiddleware(
+        // disable schema extraction by default, because the source produces raw data
+        sdk.SourceWithSchemaExtractionConfig{
+            PayloadEnabled: lang.Ptr(false),
+            KeyEnabled:     lang.Ptr(false),
+        },
+    )...,
+)
 ```
 :::
 
@@ -217,8 +217,6 @@ func (s *Source) Teardown(context.Context) error {
 }
 ```
 
-![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)
-
 ## Schema
 
 By default, the [sdk source middleware](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#SourceWithSchemaExtraction)
@@ -227,7 +225,8 @@ quite slow, as the middleware will try to create a schema for every single
 record.
 
 If the source connector is reading unstructured data, or you want to use your own
-schema extraction logic, you can disable the middleware like this:
+schema extraction logic, you can disable the middleware like this, as mentioned
+before:
 
 ```go
 func NewSource() sdk.Source {
@@ -244,6 +243,30 @@ func NewSource() sdk.Source {
 ```
 
 Otherwise you can use [schema.Create](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#Create)
-to manually handle the schema creation.
+to manually handle the schema creation:
+
+```go
+	import (
+		"github.com/conduitio/conduit-connector-sdk/schema"
+		hambaavro "github.com/hamba/avro/v2"
+	)
+
+	// create a user schema with name string and age int
+
+	recordSchema, err := avro.NewBuilder("users", "example_namespace").
+		AddField("name", hambaavro.NewPrimitiveSchema(hambaavro.String, nil)).
+		AddField("age", hambaavro.NewPrimitiveSchema(hambaavro.Int, nil)).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	s, err := schema.Create(ctx, schema.TypeAvro, "users", []byte(recordSchema.String()))
+	if err != nil {
+		panic(err)
+	}
+```
 
 An example implementation can be found in the [postgres connector](https://github.com/ConduitIO/conduit-connector-postgres).
+
+![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)

--- a/docs/2-developing/0-connectors/4-developing-destination-connectors.mdx
+++ b/docs/2-developing/0-connectors/4-developing-destination-connectors.mdx
@@ -134,3 +134,29 @@ func (d *Destination) Teardown(context.Context) error {
 ```
 
 ![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)
+
+## Schema
+
+By default, the [sdk destination middleware](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#DestinationWithSchemaExtraction) will use the record schema
+fields to decode its key and payload. This isn't as problematic as the [sdk source middleware](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#SourceWithSchemaExtraction),
+as the schema should be already created.
+
+If the destination connector is writing unstructured data, or you want to use your own
+schema writing logic, you can disable the middleware like this:
+
+```go
+func NewDestination() sdk.Destination {
+    return sdk.DestinationWithMiddleware(
+        &Destination{},
+        sdk.DefaultDestinationMiddleware(
+            sdk.DestinationWithSchemaExtractionConfig{
+                PayloadEnabled: lang.Ptr(false),
+                KeyEnabled:     lang.Ptr(false),
+            }
+        )...,
+    )
+}
+```
+
+Otherwise you can use [schema.Get](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#Get)
+to manually decode records.

--- a/docs/2-developing/0-connectors/4-developing-destination-connectors.mdx
+++ b/docs/2-developing/0-connectors/4-developing-destination-connectors.mdx
@@ -133,8 +133,6 @@ func (d *Destination) Teardown(context.Context) error {
 }
 ```
 
-![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)
-
 ## Schema
 
 By default, the [sdk destination middleware](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#DestinationWithSchemaExtraction) will use the record schema
@@ -142,7 +140,7 @@ fields to decode its key and payload. This isn't as problematic as the [sdk sour
 as the schema should be already created.
 
 If the destination connector is writing unstructured data, or you want to use your own
-schema writing logic, you can disable the middleware like this:
+schema writing logic, you can disable the middleware like this, as mentioned before:
 
 ```go
 func NewDestination() sdk.Destination {
@@ -158,5 +156,20 @@ func NewDestination() sdk.Destination {
 }
 ```
 
-Otherwise you can use [schema.Get](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#Get)
-to manually decode records.
+Otherwise you can use the schema fetched from [schema.Get](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk@v0.12.0/schema#Get)
+to manually decode records:
+
+```go
+	var rec opencdc.Record
+	sub, err := rec.Metadata.GetPayloadSchemaSubject()
+	v, err := rec.Metadata.GetPayloadSchemaVersion()
+
+	s, err := schema.Get(ctx, sub, v)
+	err = s.Unmarshal(rec.Payload.After.Bytes(), &someStruct)
+
+	// ... write the struct in any way
+```
+
+
+
+![scarf pixel conduit-site-docs-developing-connectors](https://static.scarf.sh/a.png?x-pxid=3ada0949-fa61-40d6-a44a-76447ea4e39f)

--- a/src/connectorgen/README.md
+++ b/src/connectorgen/README.md
@@ -18,7 +18,7 @@ in [update-connectors-list.yaml](/.github/workflows/update-connectors-list.yaml)
 
 ## Manual
 
-Assuming that `gh` is installed, `connectorgen` can be invoked in the following
+Assuming that [gh](https://cli.github.com/) is installed, `connectorgen` can be invoked in the following
 way:
 
 ```shell


### PR DESCRIPTION
Adds docs on how to add schema support on both source and destination connectors. I found out that the current docs don't say much about *how* to do this, so this PR should help.