### PR TITLE
Connector doc page author display

### DIFF
--- a/docs/1-using/5-connectors/7-list/3-kafka.mdx
+++ b/docs/1-using/5-connectors/7-list/3-kafka.mdx
@@ -19,46 +19,52 @@ import Tooltip from '@mui/material/Tooltip';
 
 # kafka
 
-<Stack
-  className='align-items-center'
-  direction='row'
-  justifyContent='flex-start'
-  spacing={2}
->
-    {/* Wrap each item in a container with consistent height */}
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      {/* Conduit logo */}
-      
-      <Tooltip title="Created by the Conduit team">
-        <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
-      </Tooltip>
-      
-    </Box>
+<Box sx={{
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  marginBottom: 4,
+  borderRadius: 1,
+  padding: 2,
+  backgroundColor: 'rgba(0, 0, 0, 0.03)'
+}}>
+  {/* Author info */}
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+    <span>Author: Meroxa, Inc.</span>
+    <Tooltip title="Created by the Conduit team">
+      <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
+    </Tooltip>
+  </Box>
 
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      <IconButton
-        size='large'
-        href="https://github.com/ConduitIO/conduit-connector-kafka"
-        target='_blank'
-        sx={{ padding: '12px' }}
-      >
-        <GitHubIcon fontSize='inherit' />
-      </IconButton>
-    </Box>
+  {/* Divider */}
+  <Box sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.12)', height: 24 }} />
 
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      <Chip
-        icon={<StarIcon />}
-        label="7"
-        size='large'
-        sx={{ height: 32 }}
-      />
-    </Box>
-</Stack>
+  {/* GitHub link */}
+  <Link
+    href="https://github.com/ConduitIO/conduit-connector-kafka"
+    target="_blank"
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 0.5,
+      color: 'inherit',
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'underline'
+      }
+    }}
+  >
+    <GitHubIcon sx={{ fontSize: '1.5rem' }} />
+  </Link>
 
-## Author
-
-Meroxa, Inc.
+  {/* Stars */}
+  <Chip
+    icon={<StarIcon sx={{ fontSize: '1rem' }} />}
+    label="7"
+    size="small"
+    sx={{ height: 24 }}
+  />
+</Box>
 
 ## Latest release
 

--- a/docs/1-using/5-connectors/7-list/5-postgres.mdx
+++ b/docs/1-using/5-connectors/7-list/5-postgres.mdx
@@ -19,46 +19,52 @@ import Tooltip from '@mui/material/Tooltip';
 
 # postgres
 
-<Stack
-  className='align-items-center'
-  direction='row'
-  justifyContent='flex-start'
-  spacing={2}
->
-    {/* Wrap each item in a container with consistent height */}
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      {/* Conduit logo */}
-      
-      <Tooltip title="Created by the Conduit team">
-        <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
-      </Tooltip>
-      
-    </Box>
+<Box sx={{
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  marginBottom: 4,
+  borderRadius: 1,
+  padding: 2,
+  backgroundColor: 'rgba(0, 0, 0, 0.03)'
+}}>
+  {/* Author info */}
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+    <span>Author: Meroxa, Inc.</span>
+    <Tooltip title="Created by the Conduit team">
+      <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
+    </Tooltip>
+  </Box>
 
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      <IconButton
-        size='large'
-        href="https://github.com/ConduitIO/conduit-connector-postgres"
-        target='_blank'
-        sx={{ padding: '12px' }}
-      >
-        <GitHubIcon fontSize='inherit' />
-      </IconButton>
-    </Box>
+  {/* Divider */}
+  <Box sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.12)', height: 24 }} />
 
-    <Box sx={{ display: 'flex', alignItems: 'center', height: 48 }}>
-      <Chip
-        icon={<StarIcon />}
-        label="12"
-        size='large'
-        sx={{ height: 32 }}
-      />
-    </Box>
-</Stack>
+  {/* GitHub link */}
+  <Link
+    href="https://github.com/ConduitIO/conduit-connector-postgres"
+    target="_blank"
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 0.5,
+      color: 'inherit',
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'underline'
+      }
+    }}
+  >
+    <GitHubIcon sx={{ fontSize: '1.5rem' }} />
+  </Link>
 
-## Author
-
-Meroxa, Inc.
+  {/* Stars */}
+  <Chip
+    icon={<StarIcon sx={{ fontSize: '1rem' }} />}
+    label="12"
+    size="small"
+    sx={{ height: 24 }}
+  />
+</Box>
 
 ## Latest release
 

--- a/src/connectorgen/connector-docs-mdx.tmpl
+++ b/src/connectorgen/connector-docs-mdx.tmpl
@@ -19,46 +19,52 @@ import Tooltip from '@mui/material/Tooltip';
 
 # {{ .Specifications.latest.specification.name }}
 
-<Stack
-  className='align-items-center'
-  direction='row'
-  justifyContent='flex-start'
-  spacing={2}
->
-    {/* Wrap each item in a container with consistent height */}
-    <Box sx={{printf "{{" }} display: 'flex', alignItems: 'center', height: 48 {{printf "}}" }}>
-      {/* Conduit logo */}
-      {{if or (lower .NameWithOwner | hasPrefix "conduitio/") (lower .NameWithOwner | hasPrefix "conduitio-labs/")}}
-      <Tooltip title="Created by the Conduit team">
-        <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
-      </Tooltip>
-      {{ end }}
-    </Box>
+<Box sx={{ printf "{{" }}
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  marginBottom: 4,
+  borderRadius: 1,
+  padding: 2,
+  backgroundColor: 'rgba(0, 0, 0, 0.03)'
+{{ printf "}}" }}>
+  {/* Author info */}
+  <Box sx={{ printf "{{" }} display: 'flex', alignItems: 'center', gap: 1 {{ printf "}}" }}>
+    <span>Author: {{ .Specifications.latest.specification.author }}</span>
+    <Tooltip title="Created by the Conduit team">
+      <img src='/img/conduit/conduit-ring.png' width='18' alt="Conduit team logo" />
+    </Tooltip>
+  </Box>
 
-    <Box sx={{printf "{{" }} display: 'flex', alignItems: 'center', height: 48 {{printf "}}" }}>
-      <IconButton
-        size='large'
-        href="{{ .URL }}"
-        target='_blank'
-        sx={{printf "{{" }} padding: '12px' {{printf "}}" }}
-      >
-        <GitHubIcon fontSize='inherit' />
-      </IconButton>
-    </Box>
+  {/* Divider */}
+  <Box sx={{ printf "{{" }} borderLeft: '1px solid rgba(0, 0, 0, 0.12)', height: 24 {{ printf "}}" }} />
 
-    <Box sx={{printf "{{" }} display: 'flex', alignItems: 'center', height: 48 {{printf "}}" }}>
-      <Chip
-        icon={<StarIcon />}
-        label="{{ .Stargazers }}"
-        size='large'
-        sx={{printf "{{" }} height: 32 {{printf "}}" }}
-      />
-    </Box>
-</Stack>
+  {/* GitHub link */}
+  <Link
+    href="{{ .URL }}"
+    target="_blank"
+    sx={{ printf "{{" }}
+      display: 'flex',
+      alignItems: 'center',
+      gap: 0.5,
+      color: 'inherit',
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'underline'
+      }
+    {{ printf "}}" }}
+  >
+    <GitHubIcon sx={{ printf "{{" }} fontSize: '1.5rem' {{ printf "}}" }} />
+  </Link>
 
-## Author
-
-{{ .Specifications.latest.specification.author }}
+  {/* Stars */}
+  <Chip
+    icon={<StarIcon sx={{ printf "{{" }} fontSize: '1rem' {{ printf "}}" }} />}
+    label="{{ .Stargazers }}"
+    size="small"
+    sx={{ printf "{{" }} height: 24 {{ printf "}}" }}
+  />
+</Box>
 
 ## Latest release
 {{ range $i, $release := .Releases }}


### PR DESCRIPTION
This changes the way the author, link to GitHub and star count is displayed.

![image](https://github.com/user-attachments/assets/34743d98-7560-4b4b-aba0-95f32272b1ea)
