### PR TITLE
fix: typo💂

### DIFF
--- a/changelog/2025-03-20-conduit-0-13-3-release.mdx
+++ b/changelog/2025-03-20-conduit-0-13-3-release.mdx
@@ -8,7 +8,7 @@ tags: [conduit, release]
 Today, we released a new version of Conduit [v0.13.3](https://github.com/ConduitIO/conduit/releases/tag/v0.13.3), adding new [builtin processors](/docs/using/processors/builtin) and fixing a bug when using batching delay on the connector with an older version of our [Conduit Connector SDK](https://github.com/ConduitIO/conduit-connector-sdk).
 
 :::tip
-If you're experiencing a validation issue when using `sdk.batch.delay`, make sure your connector is using at leat [Conduit Connector SDK v0.13.2](https://github.com/ConduitIO/conduit-connector-sdk/releases/tag/v0.13.2).
+If you're experiencing a validation issue when using `sdk.batch.delay`, make sure your connector is using at least [Conduit Connector SDK v0.13.2](https://github.com/ConduitIO/conduit-connector-sdk/releases/tag/v0.13.2).
 :::
 
 <!--truncate-->


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/740aa70e-d0ab-4324-8bf3-72c1e4096554)
