### PR TITLE
fixing syntax on processor building page

### DIFF
--- a/docs/2-developing/1-processors/1-building.mdx
+++ b/docs/2-developing/1-processors/1-building.mdx
@@ -181,7 +181,7 @@ The [Processor SDK](https://github.com/ConduitIO/conduit-processor-sdk) provides
 * `sdk.ParseConfig`: used to sanitize the configuration, apply defaults, validate it using builtin validations, and copy
 the values into the target object. 
 * `sdk.NewReferenceResolver`: creates a new reference resolver from the input string. The input string is a reference
-to a field in a record, check [Referencing record fields](/docs/using/processors/referencing-fields for more details.
+to a field in a record, check [Referencing record fields](/docs/using/processors/referencing-fields) for more details.
 The method will return a `resolver` that can be used to resolve a reference to the specified field in a record and
 manipulate that field (`get`, `set` and `delete` the value, or `rename` the referenced field).
 


### PR DESCRIPTION
Fix minor syntax error on [Build Your Own Processor](https://conduit.io/docs/developing/processors/building)