### PR TITLE
changelog: Conduit 0.13.5

### DIFF
--- a/changelog/2025-05-19-conduit-0-13-5-release.mdx
+++ b/changelog/2025-05-19-conduit-0-13-5-release.mdx
@@ -1,0 +1,20 @@
+---
+slug: '2025-05-19-conduit-0-13-5-release'
+title: Conduit v0.13.5 release
+draft: false
+tags: [conduit, release]
+---
+
+We're happy to announce the release of Conduit [v0.13.5](https://github.com/ConduitIO/conduit/releases/tag/v0.13.5), introducing a new Ollama processor, and several bug fixes and improvements.
+
+<!--truncate-->
+
+### More information
+
+- [Add a new Ollama Processor as built-in processor](https://github.com/ConduitIO/conduit/pull/2227). 
+- [Add the ability to easily configure Processor Plugins when building a custom Conduit](https://github.com/ConduitIO/conduit/pull/2260). Check out the [documentation page for more information](/docs/using/processors/additional-built-in-plugins). Thanks [@nickchomey](https://github.com/nickchomey) for the contribution!
+- [New configuration option `preview.pipeline-arch-v2-disable-metrics` to disable metrics for the new pipeline architecture](https://github.com/ConduitIO/conduit/pull/2271).
+- [Fixes a bug where the ENV variable `CONDUIT_CONFIG_PATH` didn't seem to work propertly](https://github.com/ConduitIO/ecdysis/issues/25).
+- [Fixes a bug when using the default processor middleware](https://github.com/ConduitIO/conduit-processor-sdk/issues/111).
+
+![scarf pixel conduit-site-changelog](https://static.scarf.sh/a.png?x-pxid=b43cda70-9a98-4938-8857-471cc05e99c5)

--- a/docs/1-using/0-installing-and-running.mdx
+++ b/docs/1-using/0-installing-and-running.mdx
@@ -33,12 +33,12 @@ First, download
 the [latest Conduit release](https://github.com/ConduitIO/conduit/releases/latest)
 for your platform.
 
-Let's say you downloaded `conduit_0.13.4_Windows_x86_64.zip`.
+Let's say you downloaded `conduit_0.13.5_Windows_x86_64.zip`.
 
 ### Unzip the archive
 
 ```shell
-tar -xf conduit_0.13.4_Windows_x86_64.zip
+tar -xf conduit_0.13.5_Windows_x86_64.zip
 ```
 
 ### Run
@@ -92,7 +92,7 @@ Before you can build Conduit from source, you need to have the latest version of
 1. Start by downloading the source code from the latest stable release on the Conduit [Releases Page](https://github.com/ConduitIO/conduit/releases/latest). Alternatively, you can run this command to automatically download the latest stable source to your current directory:
 
 ```shell
-$ TAG=v0.13.4; curl -o conduit.tar.gz -L https://github.com/ConduitIO/conduit/archive/refs/tags/$TAG.tar.gz
+$ TAG=v0.13.5; curl -o conduit.tar.gz -L https://github.com/ConduitIO/conduit/archive/refs/tags/$TAG.tar.gz
 ```
 
 A file called `conduit.tgz` will be in your current directory. The next step is to expand the source:
@@ -106,7 +106,7 @@ name might be different between releases since it's tied to the latest git sha
 for the commit.
 
 ```shell
-$ cd conduit-0.13.4
+$ cd conduit-0.13.5
 ```
 
 Now build the project:
@@ -136,7 +136,7 @@ on port 8080:
  `::::::::          ::::::::‘
       `::::        ::::‘
        `:::::....:::::‘
-         `::::::::::‘        Conduit v0.13.4 linux/amd64
+         `::::::::::‘        Conduit v0.13.5 linux/amd64
              ‘‘‘‘
 2025-01-10T09:40:07+00:00 INF All 0 tables opened in 0s component=badger.DB
 2025-01-10T09:40:07+00:00 INF Discard stats nextEmptySlot: 0 component=badger.DB

--- a/docs/1-using/1-configuration.mdx
+++ b/docs/1-using/1-configuration.mdx
@@ -78,6 +78,7 @@ pipelines.error-recovery.max-retries: -1
 pipelines.error-recovery.max-retries-window: 5m0s
 schema-registry.type: builtin
 preview.pipeline-arch-v2: false
+preview.pipeline-arch-v2-disable-metrics: false
 ```
 
 ## Environment variables

--- a/docs/1-using/1-configuration.mdx
+++ b/docs/1-using/1-configuration.mdx
@@ -47,6 +47,7 @@ Flags:
       --pipelines.exit-on-degraded                             exit Conduit if a pipeline is degraded
       --pipelines.path string                                  path to pipelines' directory (default "/Users/username/repo/conduit/pipelines")
       --preview.pipeline-arch-v2                               enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)
+      --preview.pipeline-arch-v2-disable-metrics               disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)
       --processors.path string                                 path to standalone processors' directory (default "/Users/username/repo/conduit/processors")
       --schema-registry.confluent.connection-string string     confluent schema registry connection string
       --schema-registry.type string                            schema registry type; accepts builtin,confluent (default "builtin")

--- a/docs/1-using/8-guides/build-generator-to-log-pipeline.mdx
+++ b/docs/1-using/8-guides/build-generator-to-log-pipeline.mdx
@@ -144,7 +144,7 @@ Now you can run Conduit:
  `::::::::          ::::::::‘
       `::::        ::::‘
        `:::::....:::::‘
-         `::::::::::‘        Conduit v0.13.4 linux/amd64
+         `::::::::::‘        Conduit v0.13.5 linux/amd64
              ‘‘‘‘
 2024-09-19T10:34:54+00:00 INF All 1 tables opened in 0s component=badger.DB
 2024-09-19T10:34:54+00:00 INF Discard stats nextEmptySlot: 0 component=badger.DB

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -162,8 +162,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Meroxa, Inc.`,
     },
     announcementBar: {
-      id: 'announcement-bar-11', // increment on change
-      content: `Conduit v0.13.4 is here! <a class='cta' href='/changelog/2025-04-10-conduit-0-13-4-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
+      id: 'announcement-bar-12', // increment on change
+      content: `Conduit v0.13.5 is here! <a class='cta' href='/changelog/2025-05-19-conduit-0-13-5-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
       isCloseable: true,
     },
     colorMode: {


### PR DESCRIPTION
It also add a changelog to something that had been already added to the docs (but not publicly available as part of Conduit) https://github.com/ConduitIO/conduit-site/pull/275.

### Blocked by

- [ ] [Release Conduit 0.13.5](https://github.com/ConduitIO/conduit/issues/2289)
- [ ] Generate the Ollama processor doc page
- [ ] Add link to the Ollama processor doc page from the changelog.