### PR TITLE
fix: add http API link again

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -68,6 +68,7 @@ const config: Config = {
         { to: '/docs/using/connectors/list', position: 'left', label: 'Connectors' },
         { to: '/docs', position: 'left', label: 'Documentation' },
         { to: '/changelog', position: 'left', label: 'Changelog' },
+        { to: '/api', position: 'left', label: 'HTTP API' },
         { to: 'https://meroxa.io', label: 'Conduit Platform', position: 'right', className: 'navbar__link navbar__item conduit-platform' },
         { to: 'https://meroxa.com/blog/?type=Conduit', position: 'right', label: 'Blog' },
         { to: 'https://github.com/ConduitIO', position: 'right', label: 'GitHub', className: 'svg-background github' },


### PR DESCRIPTION
There used to be a link to the HTTP API, but it was accidentally removed as part of this pull-request: https://github.com/ConduitIO/conduit-site/pull/261/files#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784L70.


![CleanShot 2025-05-21 at 7  44 21@2x](https://github.com/user-attachments/assets/f1311acf-34e4-4382-ac9f-f472b584b3ce)
