### PR TITLE
docs: refresh site for the v0.16 line (changelog, docs, positioning)

### DIFF
--- a/changelog/2024-11-08-conduit-0-12-2-release.mdx
+++ b/changelog/2024-11-08-conduit-0-12-2-release.mdx
@@ -27,7 +27,7 @@ Conduit and pipelines, as well as bug fixes.
   new commands.
 - **Bug fixes**
 
-You can install v0.12.2 with `curl https://conduit.io/install.sh | bash` or you
+You can install v0.12.2 with `curl https://conduitdata.io/install.sh | bash` or you
 can download a binary
 from [here](https://github.com/ConduitIO/conduit/releases/tag/v0.12.2).
 

--- a/changelog/2024-11-27-conduit-0-12-3-release.mdx
+++ b/changelog/2024-11-27-conduit-0-12-3-release.mdx
@@ -20,7 +20,7 @@ improvements.
 - **Internal improvements**: More tests, dependency upgrades, and documentation
   updates are also in this release.
 
-You can install v0.12.3 with `curl https://conduit.io/install.sh | bash` or you
+You can install v0.12.3 with `curl https://conduitdata.io/install.sh | bash` or you
 can download a binary
 from [here](https://github.com/ConduitIO/conduit/releases/tag/v0.12.3).
 

--- a/changelog/2026-07-04-conduit-0-15-0-release.mdx
+++ b/changelog/2026-07-04-conduit-0-15-0-release.mdx
@@ -1,0 +1,23 @@
+---
+slug: '2026-07-04-conduit-0-15-0-release'
+title: Conduit v0.15.0 release
+draft: false
+tags: [conduit, release, conduit-release]
+---
+
+[Conduit v0.15.0](https://github.com/ConduitIO/conduit/releases/tag/v0.15.0) is out — the first stable release since the project came back from about 15 months dormant. This cut stabilizes the nightly build train we've been running since restarting, and clears out a handful of provisioning and compatibility bugs that had piled up.
+
+:::tip
+Curious what's coming next? The [roadmap](/docs/future/roadmap) tracks the phases we're executing against.
+:::
+
+<!--truncate-->
+
+### Key Highlights
+
+- Fixed a backwards-compatibility regression that crashed pipelines using connectors built against the pre-lifecycle connector protocol (for example, an older Elasticsearch destination) — Conduit now falls back correctly instead of failing on `Open`.
+- Three [provisioning](/docs/using/pipelines/provisioning) fixes: pipelines created by an embedding application are no longer deleted on restart, a pipeline marked `status: stopped` in a config file now stays stopped after a restart, and one invalid document in a multi-document pipeline YAML file no longer takes the rest of the file down with it.
+- Record size estimation for metrics no longer runs a full JSON marshal per record — a plain traversal instead, cutting a meaningful chunk of metrics overhead off the hot path.
+- Toolchain bumped to Go 1.25.
+
+![scarf pixel conduit-site-changelog](https://static.scarf.sh/a.png?x-pxid=b43cda70-9a98-4938-8857-471cc05e99c5)

--- a/changelog/2026-07-04-conduit-0-15-1-release.mdx
+++ b/changelog/2026-07-04-conduit-0-15-1-release.mdx
@@ -1,0 +1,20 @@
+---
+slug: '2026-07-04-conduit-0-15-1-release'
+title: Conduit v0.15.1 release
+draft: false
+tags: [conduit, release, conduit-release]
+---
+
+[Conduit v0.15.1](https://github.com/ConduitIO/conduit/releases/tag/v0.15.1) is a same-day patch for a shutdown bug: Conduit only registered `SIGINT`, so `SIGTERM` — the signal `docker stop`, `kubectl delete pod`, and `systemctl stop` all send — bypassed graceful shutdown and killed the process immediately.
+
+:::tip
+This wasn't silent data loss on its own — at-least-once delivery and crash-safe positions still recover an abrupt kill — but it meant every container or pod recycle skipped draining in-flight records and checkpointing, causing duplicate-delivery storms and unclean checkpoints on restart.
+:::
+
+<!--truncate-->
+
+### Key Highlights
+
+- `SIGTERM` now drives the same [graceful shutdown](/docs/installing-and-running) path as `SIGINT`: in-flight records drain and pipelines checkpoint before exit, with a second signal still forcing an immediate stop.
+
+![scarf pixel conduit-site-changelog](https://static.scarf.sh/a.png?x-pxid=b43cda70-9a98-4938-8857-471cc05e99c5)

--- a/changelog/2026-07-06-conduit-0-16-0-release.mdx
+++ b/changelog/2026-07-06-conduit-0-16-0-release.mdx
@@ -1,0 +1,24 @@
+---
+slug: '2026-07-06-conduit-0-16-0-release'
+title: Conduit v0.16.0 release
+draft: false
+tags: [conduit, release, conduit-release]
+---
+
+[Conduit v0.16.0](https://github.com/ConduitIO/conduit/releases/tag/v0.16.0) is the first release built end-to-end against the Phase 1 execution plan: a real first-five-minutes experience, structured errors instead of opaque strings, and the deployment basics — readiness, liveness, metrics, full env-config — that make Conduit boring to run in a container or a pod.
+
+:::tip
+Deterministic CLI exit codes, connector-config redaction in logs, and a CI guard enforcing error-code coverage landed on `main` shortly after and ship in the upcoming v0.16.1.
+:::
+
+<!--truncate-->
+
+### Key Highlights
+
+- New [`conduit quickstart`](/docs/cli) command: one line scaffolds and runs a demo generator → log pipeline in-process — records flow to your console within seconds, no flags, nothing written to your working directory. It's the same generator-to-log combo from our [pipeline guide](/docs/using/guides/build-generator-to-log-pipeline), now zero-config.
+- [Structured errors](/docs/using/other-features/structured-errors) (`ConduitError`): user-facing errors are gaining a stable machine-actionable shape — code, the failing config path, and a suggested fix — surfaced over the gRPC/HTTP API so agents and the MCP server can act on an error instead of just printing it. Rollout is incremental across error sites.
+- `--json` now works on every read command (`list`/`describe`) across connectors, connector plugins, processors, processor plugins, and pipelines, not just `pipelines list`. See the [CLI reference](/docs/cli).
+- 12-factor essentials: a new [`/readyz` readiness endpoint](/docs/using/other-features/health-and-readiness) joins the existing `/healthz` liveness check and Prometheus [`/metrics`](/docs/using/other-features/metrics) — `/readyz` returns 503 while the engine is starting or its state store is unreachable, and reports degraded pipelines in the response body without flipping the process to not-ready. Every setting is [env-configurable](/docs/configuration) (`CONDUIT_*`, flag > env > file precedence), and `conduit run --pipelines <dir>` is now a shorthand for `--pipelines.path`.
+- Lifecycle correctness: a degraded pipeline now reports the source connector's actual error instead of a downstream `io.EOF` that masked it, and force-stop / `WaitPipeline` no longer risk a nil-pointer panic or a lost terminal error under race conditions during startup and shutdown.
+
+![scarf pixel conduit-site-changelog](https://static.scarf.sh/a.png?x-pxid=b43cda70-9a98-4938-8857-471cc05e99c5)

--- a/docs/0-what-is/1-getting-started.mdx
+++ b/docs/0-what-is/1-getting-started.mdx
@@ -29,7 +29,7 @@ If you're using a macOS or Linux system, you can install Conduit with the
 following command:
 
 ```shell
-$ curl https://conduit.io/install.sh | bash
+$ curl https://conduitdata.io/install.sh | bash
 ```
 
 If you're not using macOS or Linux system, you can still install Conduit
@@ -122,7 +122,7 @@ pipelines:
     description: "This pipeline was initialized using the `conduit pipelines init` command.
 It is a demo pipeline that connects a source connector (generator) to a destination connector (log).
 The next step is to simply run `conduit run` in your terminal and you should see a new record being logged every second.
-Check out https://conduit.io/docs/using/pipelines/configuration-file to learn about how this file is structured."
+Check out https://conduitdata.io/docs/using/pipelines/configuration-file to learn about how this file is structured."
     status: running
     name: "demo-pipeline"
     connectors:

--- a/docs/0-what-is/1-getting-started.mdx
+++ b/docs/0-what-is/1-getting-started.mdx
@@ -41,6 +41,40 @@ The Conduit binary contains both, the Conduit service and the Conduit CLI, with
 which you can interact with Conduit.
 :::
 
+## The fastest way to start
+
+Once Conduit is installed, the quickest way to see it working is a single
+command:
+
+```shell
+$ conduit quickstart
+```
+
+`conduit quickstart` scaffolds an ephemeral demo pipeline — a built-in
+[`generator`](/docs/using/connectors/list/generator) source streaming sample
+records to the built-in [`log`](/docs/using/connectors/list/log) destination —
+and runs it immediately. Records start flowing to your console within seconds:
+
+```shell
+Starting a demo pipeline (generator → log). Records will flow below — press Ctrl-C to stop.
+
+2026-07-06T12:37:28+00:00 INF ... record={"key":...,"payload":{"after":{"airline":"elytrorrhagia","scheduledDeparture":"2026-07-06T10:37:27.540841Z"},...}}
+```
+
+Everything is in-memory and nothing is written to your working directory: the
+scaffolded config lives in a temporary directory that is removed on exit, and the
+state store is in-memory, so there is nothing to clean up. Press `Ctrl + C` to
+stop.
+
+:::tip
+Add `--json` to emit the demo's logs and records as JSON instead of
+human-readable text: `conduit quickstart --json`.
+:::
+
+`conduit quickstart` is the zero-setup way to confirm Conduit runs on your
+machine. It **complements** — it doesn't replace — the manual walkthrough below,
+which is how you build a real pipeline of your own from a configuration file.
+
 ## Initialize Conduit 
 
 Firs, let's initialize the working environment:
@@ -205,6 +239,8 @@ covered, here are a few places to dive in deeper:
 - [Connectors](/docs/using/connectors/getting-started)
 - [Pipelines](/docs/using/pipelines/configuration-file)
 - [Processors](/docs/using/processors/getting-started)
+- [Health & Readiness](/docs/using/other-features/health-and-readiness) — probes for running Conduit in production
+- [Exit codes](/docs/using/other-features/exit-codes) — scriptable, deterministic process exit codes
 
 Or, if you want to experiment a bit more, check out the examples in
 our [GitHub repository](https://github.com/ConduitIO/conduit/tree/main/examples).

--- a/docs/1-using/0-installing-and-running.mdx
+++ b/docs/1-using/0-installing-and-running.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
     The recommended way of running Conduit on a local machine is using the latest version which you can install by running the following command:
     
 ```
-curl https://conduit.io/install.sh | bash
+curl https://conduitdata.io/install.sh | bash
 ```
 
 :::info

--- a/docs/1-using/1-configuration.mdx
+++ b/docs/1-using/1-configuration.mdx
@@ -86,10 +86,37 @@ preview.pipeline-arch-v2-disable-metrics: false
 ## Environment variables
 
 **Environment variables** (lower priority) - an environment variable is only
-  used if no CLI flag is provided for the same option. Environment variables
-  have the prefix `CONDUIT` and contain underscores instead of dots and
-  hyphens (e.g. the flag `--db.postgres.connection-string` corresponds
-  to `CONDUIT_DB_POSTGRES_CONNECTION_STRING`).
+  used if no CLI flag is provided for the same option. **Every** setting is
+  configurable this way: there is no flag without a matching environment
+  variable. The name is derived from the flag path mechanically:
+
+  1. Take the flag path (e.g. `api.http.address`).
+  2. Upper-case it and replace every `.` and `-` with `_`.
+  3. Prefix it with `CONDUIT_`.
+
+  | Flag                              | Environment variable                     |
+  |-----------------------------------|------------------------------------------|
+  | `--api.http.address`              | `CONDUIT_API_HTTP_ADDRESS`               |
+  | `--api.enabled`                   | `CONDUIT_API_ENABLED`                    |
+  | `--db.type`                       | `CONDUIT_DB_TYPE`                         |
+  | `--db.postgres.connection-string` | `CONDUIT_DB_POSTGRES_CONNECTION_STRING`  |
+  | `--log.level`                     | `CONDUIT_LOG_LEVEL`                       |
+
+  For example, these two invocations are equivalent:
+
+  ```shell
+  $ conduit run --api.http.address=:9090
+  ```
+
+  ```shell
+  $ CONDUIT_API_HTTP_ADDRESS=:9090 conduit run
+  ```
+
+:::note
+Because a flag always wins over an environment variable, a flag on the command
+line overrides the same setting exported in your environment. See
+[precedence](#cli-flags) above.
+:::
 
 ## Configuration file
 
@@ -106,5 +133,35 @@ preview.pipeline-arch-v2-disable-metrics: false
     postgres:
       connection-string: postgres://localhost:5432/conduitdb # -db.postgres.connection-string or CONDUIT_DB_POSTGRES_CONNECTION_STRING
   ```
+
+## Pointing Conduit at a pipelines directory
+
+The path Conduit scans for pipeline configuration files is set by
+`--pipelines.path` (env `CONDUIT_PIPELINES_PATH`). For convenience — and to make
+GitOps-style setups read cleanly — `conduit run` also accepts `--pipelines` as a
+shorthand alias for `--pipelines.path`:
+
+```shell
+$ conduit run --pipelines ./my-pipelines
+```
+
+This is equivalent to `conduit run --pipelines.path ./my-pipelines`. The argument
+can be a directory of pipeline configuration files or a single pipeline
+configuration file.
+
+## Secrets in logs
+
+Connector settings routinely carry secrets: database URLs with embedded
+passwords, SASL credentials, access keys. Conduit **redacts connector
+configuration values in its own logs** — when it logs a connector's config (for
+example while configuring a connector), every value is replaced with `***` and
+only the parameter keys stay visible. Keys are not secret and are useful for
+debugging ("which parameter is set") without revealing the value it was set to.
+
+:::note
+This redaction applies to Conduit's own log output. It does not alter the values
+Conduit passes to the connector, and it is independent of any redaction a
+connector performs on its own logs.
+:::
 
 ![scarf pixel conduit-site-docs-using](https://static.scarf.sh/a.png?x-pxid=76d5981f-cd63-422b-8cf7-eab9e99f0cd3)

--- a/docs/1-using/2-cli.mdx
+++ b/docs/1-using/2-cli.mdx
@@ -141,4 +141,49 @@ provides, with details about those parameters too.
 These same examples can be used for other commands, like `pipelines list`, `pipelines desc`, `connectors ls`,
 `connectors desc`, `processors list`, etc...
 
+## `quickstart`
+
+`conduit quickstart` is the fastest way to see Conduit working. It scaffolds an
+ephemeral demo pipeline — a built-in `generator` source streaming sample records
+to the built-in `log` destination — and runs it immediately, so records flow to
+your console within seconds:
+
+```shell
+$ conduit quickstart
+Starting a demo pipeline (generator → log). Records will flow below — press Ctrl-C to stop.
+```
+
+Unlike `conduit run`, `quickstart` needs no configuration and writes nothing to
+your working directory: the scaffolded config lives in a temporary directory that
+is removed on exit, and the state store is in-memory. Press `Ctrl + C` to stop.
+
+| Flag     | Description                                                       |
+|----------|-------------------------------------------------------------------|
+| `--json` | Emit the demo's logs and records as JSON instead of human text.   |
+
+It's meant for a quick "does this work" check. To build and run a pipeline of
+your own, see [Getting Started](/docs/getting-started) and
+[`pipelines init`](/docs/using/pipelines/configuration-file).
+
+## JSON output
+
+The read commands that talk to a running Conduit — `pipelines list`,
+`pipelines describe`, `connectors list`/`describe`, `processors list`/`describe`,
+`connector-plugins list`/`describe`, and `processor-plugins list`/`describe` —
+accept a `--json` flag. With `--json`, the command prints the result as JSON
+matching the [HTTP API](/docs/using/other-features/api) shape instead of the
+human-readable table:
+
+```shell
+$ conduit pipelines list --json
+```
+
+`--json` makes the CLI scriptable and agent-legible: the same structured data the
+API returns, without parsing table output. Errors are structured too — see
+[Structured errors & JSON output](/docs/using/other-features/structured-errors).
+
+Conduit's exit codes are also deterministic, so a script can branch on the kind
+of failure without reading the error text — see
+[Exit codes](/docs/using/other-features/exit-codes).
+
 ![scarf pixel conduit-site-docs-using](https://static.scarf.sh/a.png?x-pxid=76d5981f-cd63-422b-8cf7-eab9e99f0cd3)

--- a/docs/1-using/5-connectors/4-kafka-connect-connector.mdx
+++ b/docs/1-using/5-connectors/4-kafka-connect-connector.mdx
@@ -81,7 +81,7 @@ Now that the Kafka Connect connectors included in `lib`, we can use it in a pipe
 
 1. [Install Conduit](https://github.com/ConduitIO/conduit#installation-guide).
 2. Create a pipeline configuration file: Create a folder called `pipelines` at the same level as your Conduit 
-binary. Inside of that folder create a file named `jdbc-to-file.yml`, check [Specifications](https://conduit.io/docs/using/pipelines/configuration-file)
+binary. Inside of that folder create a file named `jdbc-to-file.yml`, check [Specifications](https://conduitdata.io/docs/using/pipelines/configuration-file)
 for more details about Pipeline Configuration Files.
 
 ````yaml

--- a/docs/1-using/5-connectors/7-list/1-file.mdx
+++ b/docs/1-using/5-connectors/7-list/1-file.mdx
@@ -184,7 +184,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/15-box.mdx
+++ b/docs/1-using/5-connectors/7-list/15-box.mdx
@@ -185,7 +185,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/17-chaos.mdx
+++ b/docs/1-using/5-connectors/7-list/17-chaos.mdx
@@ -79,7 +79,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 ## Description
 
-A [Conduit](https://conduit.io) connector that can be configured to behave in
+A [Conduit](https://conduitdata.io) connector that can be configured to behave in
 unexpected ways to figure out how Conduit handles it.
 
 ## Modes
@@ -210,7 +210,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/22-dropbox.mdx
+++ b/docs/1-using/5-connectors/7-list/22-dropbox.mdx
@@ -259,7 +259,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/23-dynamodb.mdx
+++ b/docs/1-using/5-connectors/7-list/23-dynamodb.mdx
@@ -260,7 +260,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/29-google-drive.mdx
+++ b/docs/1-using/5-connectors/7-list/29-google-drive.mdx
@@ -155,7 +155,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/3-kafka.mdx
+++ b/docs/1-using/5-connectors/7-list/3-kafka.mdx
@@ -102,7 +102,7 @@ connector SDK:
 - `sdk.record.format`: used to choose the format
 - `sdk.record.format.options`: used to configure the specifics of the chosen format
 
-See [this article](https://conduit.io/docs/connectors/output-formats) for more
+See [this article](https://conduitdata.io/docs/connectors/output-formats) for more
 info on configuring the output format.
 
 ### Batching
@@ -315,7 +315,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/33-http.mdx
+++ b/docs/1-using/5-connectors/7-list/33-http.mdx
@@ -184,7 +184,7 @@ pipelines:
           # URL is a Go template expression for the URL used in the HTTP
           # request, using Go [templates](https://pkg.go.dev/text/template). The
           # value provided to the template is
-          # [opencdc.Record](https://conduit.io/docs/using/opencdc-record), so
+          # [opencdc.Record](https://conduitdata.io/docs/using/opencdc-record), so
           # the template has access to all its fields (e.g. .Position, .Key,
           # .Metadata, and so on). We also inject all template functions
           # provided by [sprig](https://masterminds.github.io/sprig/) to make it
@@ -225,7 +225,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/35-influxdb.mdx
+++ b/docs/1-using/5-connectors/7-list/35-influxdb.mdx
@@ -201,7 +201,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/39-mongo.mdx
+++ b/docs/1-using/5-connectors/7-list/39-mongo.mdx
@@ -316,7 +316,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/4-log.mdx
+++ b/docs/1-using/5-connectors/7-list/4-log.mdx
@@ -97,7 +97,7 @@ the log level of the connector in order for the records to show up in the logs.
 
 ### Known issues
 
-- **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
+- **Only when using as a [standalone connector](https://conduitdata.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
   This is a known issue caused by the default buffer value of `go-plugin`. More information can be found in [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
 
 
@@ -144,7 +144,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/40-mysql.mdx
+++ b/docs/1-using/5-connectors/7-list/40-mysql.mdx
@@ -88,7 +88,7 @@ Snapshot mode is the first stage of the source sync process. It reads all rows
 from the configured tables as record snapshots.
 
 In snapshot mode, the record payload consists of
-[opencdc.StructuredData](https://conduit.io/docs/using/opencdc-record#structured-data),
+[opencdc.StructuredData](https://conduitdata.io/docs/using/opencdc-record#structured-data),
 with each key being a column and each value being that column's value.
 
 ### Change Data Capture mode
@@ -143,7 +143,7 @@ The source connector uses [avro](https://avro.apache.org/docs/1.11.1/specificati
 
 ### Record structure
 
-Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduit.io/docs/using/opencdc-record):
+Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduitdata.io/docs/using/opencdc-record):
 
 *   **Operation**: Indicates the type of change (`create`, `update`, `delete`, `snapshot`).
 *   **Payload**:
@@ -153,7 +153,7 @@ Records produced by the MySQL source connector contain the following [opencdc re
 *   **Position**: Represents the point in the data stream. It's a JSON object containing *either* a `snapshot_position` field *or* a `cdc_position` field, structured as described below.
 *   **Metadata**: Contains standard OpenCDC fields plus:
     *   `mysql.server.id`: (CDC only) The originating MySQL server ID from the replication event header.
-    *   [Key](https://conduit.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduit.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
+    *   [Key](https://conduitdata.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduitdata.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
 
 #### Snapshot Records
 
@@ -335,7 +335,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/49-rabbitmq.mdx
+++ b/docs/1-using/5-connectors/7-list/49-rabbitmq.mdx
@@ -318,7 +318,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/5-postgres.mdx
+++ b/docs/1-using/5-connectors/7-list/5-postgres.mdx
@@ -294,7 +294,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/56-snowflake.mdx
+++ b/docs/1-using/5-connectors/7-list/56-snowflake.mdx
@@ -347,7 +347,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/6-s3.mdx
+++ b/docs/1-using/5-connectors/7-list/6-s3.mdx
@@ -258,7 +258,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/5-connectors/7-list/7-activemq.mdx
+++ b/docs/1-using/5-connectors/7-list/7-activemq.mdx
@@ -79,7 +79,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 ## Description
 
-The ActiveMQ Classic connector is one of [Conduit](https://conduit.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
+The ActiveMQ Classic connector is one of [Conduit](https://conduitdata.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
 
 It uses the [stomp protocol](https://stomp.github.io/) to connect to ActiveMQ.
 
@@ -266,7 +266,7 @@ pipelines:
           sdk.rate.perSecond: "0"
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
-          # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          # (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           sdk.record.format: "opencdc/json"
           # Options to configure the chosen output record format. Options are

--- a/docs/1-using/6-processors/1-builtin/avro.decode.mdx
+++ b/docs/1-using/6-processors/1-builtin/avro.decode.mdx
@@ -43,7 +43,7 @@ pipelines:
         settings:
           # The field that will be decoded.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ".Payload.After"
           # Whether to decode the record key using its corresponding schema from
@@ -79,7 +79,7 @@ pipelines:
         <td>
   The field that will be decoded.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/avro.encode.mdx
+++ b/docs/1-using/6-processors/1-builtin/avro.encode.mdx
@@ -56,7 +56,7 @@ pipelines:
         settings:
           # The field that will be encoded.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ".Payload.After"
           # The subject name under which the inferred schema will be registered
@@ -116,7 +116,7 @@ pipelines:
         <td>
   The field that will be encoded.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/base64.decode.mdx
+++ b/docs/1-using/6-processors/1-builtin/base64.decode.mdx
@@ -38,7 +38,7 @@ pipelines:
           # Field is the reference to the target field. Note that it is not
           # allowed to base64 decode the `.Position` field.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -75,7 +75,7 @@ pipelines:
   Field is the reference to the target field. Note that it is not allowed to
 base64 decode the `.Position` field.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/base64.encode.mdx
+++ b/docs/1-using/6-processors/1-builtin/base64.encode.mdx
@@ -40,7 +40,7 @@ pipelines:
           # Field is a reference to the target field. Note that it is not
           # allowed to base64 encode the `.Position` field.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -77,7 +77,7 @@ pipelines:
   Field is a reference to the target field. Note that it is not allowed to
 base64 encode the `.Position` field.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/clone.mdx
+++ b/docs/1-using/6-processors/1-builtin/clone.mdx
@@ -22,7 +22,7 @@ outputs the original record plus N clones (for a total of N+1 records). Each clo
 is identical to the original, except the metadata field `clone.index` is
 set to the clone's index (0 for the original, 1 to N for the clones).
 
-**Important:** Add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor if you only want to clone some records.
 
 **Important:** This processor currently only works using the pipeline architecture

--- a/docs/1-using/6-processors/1-builtin/error.mdx
+++ b/docs/1-using/6-processors/1-builtin/error.mdx
@@ -20,7 +20,7 @@ Returns an error for all records that get passed to the processor.
 Any time a record is passed to this processor it returns an error,
 which results in the record being sent to the DLQ if it's configured, or the pipeline stopping.
 
-**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor, otherwise all records will trigger an error.
 
 ## Configuration parameters

--- a/docs/1-using/6-processors/1-builtin/field.convert.mdx
+++ b/docs/1-using/6-processors/1-builtin/field.convert.mdx
@@ -43,7 +43,7 @@ pipelines:
           # can only convert fields in structured data under `.Key` and
           # `.Payload`.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -85,7 +85,7 @@ pipelines:
 Note that you can only convert fields in structured data under `.Key` and
 `.Payload`.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/field.exclude.mdx
+++ b/docs/1-using/6-processors/1-builtin/field.exclude.mdx
@@ -43,7 +43,7 @@ pipelines:
           # Fields is a comma separated list of target fields which should be
           # excluded.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           fields: ""
           # Whether to decode the record key using its corresponding schema from
@@ -79,7 +79,7 @@ pipelines:
         <td>
   Fields is a comma separated list of target fields which should be excluded.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/field.rename.mdx
+++ b/docs/1-using/6-processors/1-builtin/field.rename.mdx
@@ -44,7 +44,7 @@ pipelines:
           # their new names (keys and values are separated by colons ":").
           # For example: `.Metadata.key:id,.Payload.After.foo:bar`.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           mapping: ""
           # Whether to decode the record key using its corresponding schema from
@@ -83,7 +83,7 @@ new names (keys and values are separated by colons ":").
 
 For example: `.Metadata.key:id,.Payload.After.foo:bar`.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/field.set.mdx
+++ b/docs/1-using/6-processors/1-builtin/field.set.mdx
@@ -42,7 +42,7 @@ pipelines:
           # Field is the target field that will be set. Note that it is not
           # allowed to set the `.Position` field.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -83,7 +83,7 @@ pipelines:
   Field is the target field that will be set. Note that it is not allowed
 to set the `.Position` field.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/filter.mdx
+++ b/docs/1-using/6-processors/1-builtin/filter.mdx
@@ -21,7 +21,7 @@ Acknowledges all records that get passed to the filter, so
 the records will be filtered out if the condition provided to the processor is
 evaluated to `true`.
 
-**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor, otherwise all records will be filtered out.
 
 ## Configuration parameters

--- a/docs/1-using/6-processors/1-builtin/json.decode.mdx
+++ b/docs/1-using/6-processors/1-builtin/json.decode.mdx
@@ -42,7 +42,7 @@ pipelines:
           # Field is a reference to the target field. Only fields that are under
           # `.Key` and `.Payload` can be decoded.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -79,7 +79,7 @@ pipelines:
   Field is a reference to the target field. Only fields that are under
 `.Key` and `.Payload` can be decoded.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/json.encode.mdx
+++ b/docs/1-using/6-processors/1-builtin/json.encode.mdx
@@ -41,7 +41,7 @@ pipelines:
           # Field is a reference to the target field. Only fields that are under
           # `.Key` and `.Payload` can be encoded.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -78,7 +78,7 @@ pipelines:
   Field is a reference to the target field. Only fields that are under
 `.Key` and `.Payload` can be encoded.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/split.mdx
+++ b/docs/1-using/6-processors/1-builtin/split.mdx
@@ -55,7 +55,7 @@ pipelines:
           # processor returns an error. This also means you can only split on
           # fields in structured data under `.Key` and `.Payload`.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ""
           # Whether to decode the record key using its corresponding schema from
@@ -94,7 +94,7 @@ field has to contain an array so it can be split, otherwise the processor
 returns an error. This also means you can only split on fields in
 structured data under `.Key` and `.Payload`.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/unwrap.debezium.mdx
+++ b/docs/1-using/6-processors/1-builtin/unwrap.debezium.mdx
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 # `unwrap.debezium`
 
-Unwraps a Debezium record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).
+Unwraps a Debezium record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).
 
 ## Description
 
@@ -23,7 +23,7 @@ completely, except for the position.
 The Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.
 
 This is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. 
-In such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.
+In such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.
 
 ## Configuration parameters
 
@@ -42,7 +42,7 @@ pipelines:
         settings:
           # Field is a reference to the field that contains the Debezium record.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ".Payload.After"
           # Whether to decode the record key using its corresponding schema from
@@ -78,7 +78,7 @@ pipelines:
         <td>
   Field is a reference to the field that contains the Debezium record.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/6-processors/1-builtin/unwrap.kafkaconnect.mdx
+++ b/docs/1-using/6-processors/1-builtin/unwrap.kafkaconnect.mdx
@@ -13,16 +13,16 @@ import TabItem from '@theme/TabItem';
 
 # `unwrap.kafkaconnect`
 
-Unwraps a Kafka Connect record from an [OpenCDC record](https://conduit.io/docs/using/opencdc-record).
+Unwraps a Kafka Connect record from an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).
 
 ## Description
 
-This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).
+This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).
 
 The input record's payload is replaced with the Kafka Connect record.
 
 This is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. 
-In such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.
+In such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.
 
 ## Configuration parameters
 
@@ -42,7 +42,7 @@ pipelines:
           # Field is a reference to the field that contains the Kafka Connect
           # record.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ".Payload.After"
           # Whether to decode the record key using its corresponding schema from
@@ -78,7 +78,7 @@ pipelines:
         <td>
   Field is a reference to the field that contains the Kafka Connect record.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>
@@ -124,7 +124,7 @@ For more information about the format, see [Referencing fields](https://conduit.
 This example shows how to unwrap a Kafka Connect record.
 
 The Kafka Connect record is serialized as a JSON string in the `.Payload.After` field (raw data).
-The Kafka Connect record's payload will replace the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload.
+The Kafka Connect record's payload will replace the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload.
 
 We also see how the key is unwrapped too. In this case, the key comes in as structured data.
 

--- a/docs/1-using/6-processors/1-builtin/unwrap.opencdc.mdx
+++ b/docs/1-using/6-processors/1-builtin/unwrap.opencdc.mdx
@@ -13,15 +13,15 @@ import TabItem from '@theme/TabItem';
 
 # `unwrap.opencdc`
 
-Unwraps an [OpenCDC record](https://conduit.io/docs/using/opencdc-record) saved in one of the record's fields.
+Unwraps an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) saved in one of the record's fields.
 
 ## Description
 
 The `unwrap.opencdc` processor is useful in situations where a record goes through intermediate
-systems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is part of the payload
+systems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is part of the payload
 read from the intermediate system and needs to be unwrapped before being written.
 
-Note: if the wrapped [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.
+Note: if the wrapped [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.
 
 ## Configuration parameters
 
@@ -40,7 +40,7 @@ pipelines:
         settings:
           # Field is a reference to the field that contains the OpenCDC record.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           field: ".Payload.After"
           # Whether to decode the record key using its corresponding schema from
@@ -76,7 +76,7 @@ pipelines:
         <td>
   Field is a reference to the field that contains the OpenCDC record.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>
@@ -117,9 +117,9 @@ For more information about the format, see [Referencing fields](https://conduit.
 
 ## Examples
 
-### Unwrap an [OpenCDC record](https://conduit.io/docs/using/opencdc-record)
+### Unwrap an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)
 
-In this example we use the `unwrap.opencdc` processor to unwrap the [OpenCDC record](https://conduit.io/docs/using/opencdc-record) found in the record's `.Payload.After` field.
+In this example we use the `unwrap.opencdc` processor to unwrap the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) found in the record's `.Payload.After` field.
 
 #### Configuration parameters
 

--- a/docs/1-using/6-processors/1-builtin/webhook.http.mdx
+++ b/docs/1-using/6-processors/1-builtin/webhook.http.mdx
@@ -81,13 +81,13 @@ pipelines:
           request.url: ""
           # Specifies in which field should the response body be saved.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           response.body: ".Payload.After"
           # Specifies in which field should the response status be saved. If no
           # value is set, then the response status will NOT be saved.
           # For more information about the format, see [Referencing
-          # fields](https://conduit.io/docs/using/processors/referencing-fields).
+          # fields](https://conduitdata.io/docs/using/processors/referencing-fields).
           # Type: string
           response.status: ""
           # Whether to decode the record key using its corresponding schema from
@@ -203,7 +203,7 @@ to make it easier to write templates.
         <td>
   Specifies in which field should the response body be saved.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>
@@ -214,7 +214,7 @@ For more information about the format, see [Referencing fields](https://conduit.
   Specifies in which field should the response status be saved. If no value
 is set, then the response status will NOT be saved.
 
-For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
         </td>
       </tr>
       <tr>

--- a/docs/1-using/7-other-features/10-structured-errors.mdx
+++ b/docs/1-using/7-other-features/10-structured-errors.mdx
@@ -1,0 +1,114 @@
+---
+title: 'Structured errors & JSON output'
+slug: '/using/other-features/structured-errors'
+---
+
+:::note
+Conduit's structured error model and `--json` output shipped in **Conduit v0.16.0**;
+a CI guard enforcing error-code coverage followed in **v0.16.1**. The model is rolling
+out boundary by boundary, so not every error carries every field yet — see
+[Coverage today](#coverage-today).
+:::
+
+Conduit is built to be driven by scripts and agents as well as people. Two
+features make its output machine-actionable: **structured errors** that carry a
+stable code (plus, where available, the failing config path and a suggested fix),
+and **`--json`** output on the read commands.
+
+## Structured errors
+
+When Conduit rejects a request, the error isn't just a prose string. It carries a
+stable, machine-readable identity so a caller can react to _what_ went wrong
+without pattern-matching the message text. A structured error can include:
+
+- **`code`** — a stable, dotted identifier, e.g. `connector.plugin_not_found`.
+  The code never changes across versions, so it's safe to branch on.
+- **`message`** — a human-readable description (with any secret values redacted).
+- **`configPath`** — a JSON pointer into the offending pipeline config, e.g.
+  `/connectors/1/plugin`, when the error is tied to a specific field.
+- **`suggestion`** — a human-readable hint for fixing it, when available.
+- **`fix`** — a structured, machine-appliable change (a config path, an operation,
+  and a value) that a tool can apply directly, when available.
+
+Because the code is stable and explicit, an agent can self-correct (retry with a
+different plugin, add a missing setting) and a UI can render an actionable
+message instead of a raw string — the same information a human reads.
+
+## The API error shape
+
+Over the HTTP and gRPC APIs, structured errors are **additive**: the existing
+error shape is unchanged, and the structured fields ride along as an extra
+detail. Concretely, an error is a standard `google.rpc.Status` (top-level `code`
+and `message`, exactly as before) with a `google.rpc.ErrorInfo` detail carrying:
+
+- `reason` — the stable code (e.g. `connector.plugin_not_found`);
+- `domain` — always `conduit`;
+- `metadata` — the optional `configPath`, `suggestion`, `docsUrl`, and `fix`.
+
+An HTTP error body therefore looks like this:
+
+```json
+{
+  "code": 5,
+  "message": "connector plugin \"generatorr\" not found",
+  "details": [
+    {
+      "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+      "reason": "connector.plugin_not_found",
+      "domain": "conduit",
+      "metadata": {
+        "configPath": "/connectors/0/plugin",
+        "suggestion": "check the plugin name; run 'conduit connector-plugins list'"
+      }
+    }
+  ]
+}
+```
+
+Because the addition is a detail on the existing `Status`, consumers that only
+read `code`/`message` keep working unchanged, while agents and the UI can read
+the `ErrorInfo` for the stable reason and the structured fields.
+
+## `--json` on read commands
+
+The read commands that talk to a running Conduit accept a `--json` flag:
+
+```shell
+$ conduit pipelines list --json
+$ conduit pipelines describe my-pipeline --json
+$ conduit connectors list --json
+$ conduit connector-plugins describe builtin:postgres@latest --json
+```
+
+With `--json`, the command prints the result as JSON matching the HTTP API shape
+(the same structured data, without parsing a table). The commands that support it
+are `pipelines list`/`describe`, `connectors list`/`describe`,
+`processors list`/`describe`, `connector-plugins list`/`describe`, and
+`processor-plugins list`/`describe`. The [`quickstart`](/docs/cli#quickstart)
+command also takes `--json` to emit its demo records as JSON.
+
+## For agents
+
+Together these make Conduit legible to an agent without screen-scraping:
+
+- Read state with `--json` (or the [HTTP API](/docs/using/other-features/api))
+  and consume structured data.
+- On failure, branch on the stable error `code` and, when present, apply the
+  `fix` or act on the `configPath`/`suggestion`.
+- Branch on the process [exit code](/docs/using/other-features/exit-codes) to
+  distinguish a validation error (`2`) from an environment problem (`3`) without
+  reading any text.
+
+## Coverage today
+
+The structured error model is rolling out **boundary by boundary**, starting with
+the highest-value user-facing surfaces (config validation, pipeline provisioning,
+and Conduit-side connector/plugin errors). Errors that haven't been migrated yet
+still surface with a code, but fall back to a generic one (`internal.unknown`)
+and may not carry a `configPath`, `suggestion`, or `fix`. The `code` and
+`message` fields are always present; the richer fields are optional and populated
+as coverage grows. Errors raised by a running connector plugin about its own
+operation (bad credentials, a missing table) are a separate, later step that
+requires a connector-protocol change.
+
+![scarf pixel conduit-site-docs-using-other-features](https://static.scarf.sh/a.png?x-pxid=8c8ff6d5-2756-41a3-b4ca-3ca2be381842)

--- a/docs/1-using/7-other-features/5-api.mdx
+++ b/docs/1-using/7-other-features/5-api.mdx
@@ -18,7 +18,7 @@ The REST API is by default running on port 8080. You can define a custom address
 using the CLI flag `-http.address`. It is generated
 using [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway) and is thus
 providing the same functionality as the gRPC API. To learn more about the REST
-API please have a look at the [API documentation](https://www.conduit.io/api),
+API please have a look at the [API documentation](https://www.conduitdata.io/api),
 [OpenAPI definition](https://github.com/ConduitIO/conduit/blob/main/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json)
 or run Conduit and navigate to
 [`http://localhost:8080/openapi`](http://localhost:8080/openapi) to open

--- a/docs/1-using/7-other-features/6-metrics.mdx
+++ b/docs/1-using/7-other-features/6-metrics.mdx
@@ -7,6 +7,12 @@ are exposed through an HTTP API and ready to be scraped by Prometheus. It's also
 possible to easily define new metrics with existing types, or just create a
 completely new metric type.
 
+:::tip
+Conduit also exposes liveness (`/healthz`) and readiness (`/readyz`) probes on
+the same HTTP address. See
+[Health & Readiness](/docs/using/other-features/health-and-readiness).
+:::
+
 ## Accessing metrics
 
 Metrics are exposed at `/metrics`. For example, if you're running Conduit

--- a/docs/1-using/7-other-features/8-health-and-readiness.mdx
+++ b/docs/1-using/7-other-features/8-health-and-readiness.mdx
@@ -1,0 +1,97 @@
+---
+title: 'Health & Readiness'
+slug: '/using/other-features/health-and-readiness'
+---
+
+Conduit exposes two distinct HTTP probes, following the standard
+liveness/readiness split used by orchestrators such as Kubernetes:
+
+- **`/healthz` (liveness)** — is the Conduit process alive and able to reach its
+  state store? Use it to decide whether to **restart** the process.
+- **`/readyz` (readiness)** — is the engine finished starting up and able to
+  serve? Use it to decide whether to **route traffic**.
+
+Both are served on the HTTP API address (`:8080` by default; see
+[Configuration](/docs/configuration)).
+
+## Liveness — `/healthz`
+
+The liveness check verifies that Conduit can successfully connect to the database
+it was configured with (BadgerDB, PostgreSQL, SQLite, or the in-memory one). It's
+available at the `/healthz` path:
+
+```shell
+$ curl "http://localhost:8080/healthz"
+{"status":"SERVING"}
+```
+
+You can also check an individual service within Conduit. The following example
+checks whether the `PipelineService` is running:
+
+```shell
+$ curl "http://localhost:8080/healthz?service=PipelineService"
+{"status":"SERVING"}
+```
+
+The services that can be checked for health are `PipelineService`,
+`ConnectorService`, `ProcessorService`, and `PluginService`.
+
+## Readiness — `/readyz`
+
+The readiness check reports whether the engine can serve requests. It returns:
+
+- **`503 Service Unavailable`** with `{"status":"starting"}` while the engine is
+  still starting up (services initializing, pipelines provisioning, API coming
+  online).
+- **`503 Service Unavailable`** with `{"status":"unavailable","reason":"…"}` if
+  the engine has started but its state store is unreachable.
+- **`200 OK`** with `{"status":"ready", …}` once the engine can serve.
+
+```shell
+$ curl "http://localhost:8080/readyz"
+{
+  "status": "ready",
+  "pipelines": {
+    "total": 3,
+    "running": 2,
+    "degraded": 1,
+    "degradedPipelines": [
+      {"id": "pg-to-kafka", "status": "degraded", "error": "source connector error"}
+    ]
+  }
+}
+```
+
+:::note
+A **degraded pipeline does not make Conduit "not ready."** The engine can still
+serve requests, so degraded pipelines are reported in the response body rather
+than flipping the probe to `503`. Watch them through the `pipelines` block above
+(and through [metrics](/docs/using/other-features/metrics)); use `/readyz` only
+to decide whether the engine itself can accept traffic.
+:::
+
+## Using the probes with Kubernetes
+
+Map the probes directly onto the Kubernetes probe types:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8080
+```
+
+`/healthz` decides restarts; `/readyz` decides whether traffic is routed to the
+pod. Because a degraded pipeline keeps `/readyz` at `200`, a single failing
+pipeline won't pull the whole instance out of service.
+
+## Metrics
+
+Prometheus metrics are exposed at `/metrics` on the same HTTP address. See
+[Metrics](/docs/using/other-features/metrics) for the full list.
+
+![scarf pixel conduit-site-docs-using-other-features](https://static.scarf.sh/a.png?x-pxid=8c8ff6d5-2756-41a3-b4ca-3ca2be381842)

--- a/docs/1-using/7-other-features/9-exit-codes.mdx
+++ b/docs/1-using/7-other-features/9-exit-codes.mdx
@@ -1,0 +1,93 @@
+---
+title: 'Exit codes'
+slug: '/using/other-features/exit-codes'
+---
+
+:::note
+Deterministic exit codes were introduced in **Conduit v0.16.1**.
+:::
+
+Every `conduit` invocation — one-shot commands (`conduit pipelines list`, …) and
+the long-running `conduit run` — exits with one of a small set of deterministic
+codes. This lets scripts and agents branch on the **kind** of failure without
+parsing error text.
+
+## The codes
+
+| Code  | Meaning       | When you see it                                                                                       |
+|-------|---------------|-------------------------------------------------------------------------------------------------------|
+| `0`   | Success       | The command succeeded, or `conduit run` shut down gracefully on a single `SIGINT`/`SIGTERM` (`Ctrl+C`). |
+| `1`   | Runtime error | An internal or unclassified error — a bug or an unexpected failure.                                    |
+| `2`   | Validation    | The request or config was rejected: invalid argument, not found, already exists, or a failed precondition. |
+| `3`   | Environment   | A required external dependency is unreachable: the server, the database, a rate limit, or an already-bound listen address. |
+
+A few examples:
+
+- `conduit pipelines describe does-not-exist` → **`2`** (not found).
+- A client command run while no `conduit run` server is up → **`3`** (server
+  unreachable).
+- `conduit run` with a listen address already in use → **`3`** (bind-in-use).
+- `conduit run` shut down cleanly with a single `Ctrl+C` → **`0`**.
+
+:::note
+`FailedPrecondition` and `NotFound` are classified as **validation** (`2`), not
+runtime: they mean the request was rejected because of the state of the world the
+caller controls (a pipeline is already running, a referenced instance doesn't
+exist) — a validation-shaped failure from the caller's point of view, not an
+internal bug.
+:::
+
+## Forced shutdown: `128 + signum`
+
+`conduit run` treats a **second** `SIGINT`/`SIGTERM` — received after the first
+one has already started a graceful shutdown — as a forced kill, and exits with
+the POSIX `128 + signum` convention instead of a classified code:
+
+| Signal            | Exit code |
+|-------------------|-----------|
+| `SIGINT` (`Ctrl+C`) | `130`   |
+| `SIGTERM`         | `143`     |
+
+This is the same value a shell reports for a process killed by that signal, so a
+forced kill is distinguishable from an ordinary classified exit. (Press `Ctrl+C`
+once to drain in-flight records and exit `0`; press it a second time to stop
+waiting.)
+
+:::caution
+This is a **breaking change** from earlier versions, where a forced second-signal
+kill exited with `2`. If a supervisor (systemd, a Docker healthcheck, a CI job)
+specifically checked for exit code `2` on a forced Conduit kill, update it to
+expect `130`/`143`. Exit codes `0` (success) and `1` (default failure) are
+unchanged for every case that produced them before.
+:::
+
+## Scripting on exit codes
+
+Because the codes are stable, a script can react to the failure kind directly:
+
+```shell
+conduit pipelines describe "$PIPELINE_ID"
+case $? in
+  0) echo "ok" ;;
+  2) echo "no such pipeline (or invalid request)" ;;
+  3) echo "conduit server or its dependency is unreachable" ;;
+  *) echo "runtime error" ;;
+esac
+```
+
+For the structured detail behind a failure (a stable error code, the failing
+config path, a suggested fix), see
+[Structured errors & JSON output](/docs/using/other-features/structured-errors).
+
+## Coverage today
+
+The environment bucket (`3`) is intentionally under-covered for now: only the
+highest-value cases are tagged as environment failures — a server that's
+unreachable, a database that can't be opened, and an already-bound listen
+address. An environment-class failure outside those cases still exits `1` (the
+catch-all) rather than `3`. This is a deliberate, documented starting point, not
+a regression — `1` was the exit code for every `conduit run` failure before
+deterministic exit codes existed. Coverage grows as more boundaries adopt Conduit's
+[structured error](/docs/using/other-features/structured-errors) model.
+
+![scarf pixel conduit-site-docs-using-other-features](https://static.scarf.sh/a.png?x-pxid=8c8ff6d5-2756-41a3-b4ca-3ca2be381842)

--- a/docs/2-developing/0-connectors/4-developing-source-connectors.mdx
+++ b/docs/2-developing/0-connectors/4-developing-source-connectors.mdx
@@ -72,7 +72,7 @@ successful position. If needed, the connector should open connections in this
 function.
 
 Every record read by a source connector has
-a [position](https://conduit.io/docs/using/opencdc-record#fields) attached.
+a [position](https://conduitdata.io/docs/using/opencdc-record#fields) attached.
 The position given to `Open()` is the position of the record that was the last
 to be successfully processed end-to-end, before the connector stopped, or `nil`
 if no records were read. Hence, a position needs to contain enough information

--- a/docs/3-scaling/0-conduit-operator.mdx
+++ b/docs/3-scaling/0-conduit-operator.mdx
@@ -15,7 +15,7 @@ as a distinct Conduit instance with its own lifecycle.
 The Conduit custom resource definition format is very similar to that of [pipeline configurations](/docs/using/pipelines/configuration-file):
 
 ```yaml
-apiVersion: operator.conduit.io/v1alpha
+apiVersion: operator.conduitdata.io/v1alpha
 kind: Conduit
 metadata:
   name: conduit-generator
@@ -74,7 +74,7 @@ Plugin version can optionally be specified or the latest will be used.
 Here's a full example using [`conduitio/conduit-connector-generator`](https://github.com/conduitio/conduit-connector-generator) as `plugin` and `v0.8.0` as `pluginVersion`:
 
 ```yaml
-apiVersion: operator.conduit.io/v1alpha
+apiVersion: operator.conduitdata.io/v1alpha
 kind: Conduit
 metadata:
   name: conduit-generator
@@ -118,7 +118,7 @@ Details are provided directly via the Conduit resource. `basicAuthUser` and `bas
 #### Example
 
 ```yaml
-apiVersion: operator.conduit.io/v1alpha
+apiVersion: operator.conduitdata.io/v1alpha
 kind: Conduit
 metadata:
   name: conduit-generator-schema-registry

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
   
   // Set the production url of your site here
-  url: 'https://conduit.io',
+  url: 'https://conduitdata.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,8 +3,8 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'Conduit | Data Integration for Production Data Stores',
-  tagline: 'Sync data between your production systems using an extensible, event-first experience with minimal dependencies that fit within your existing workflow for free.',
+  title: 'Conduit | The Open-Source Kafka Connect Replacement',
+  tagline: 'The open-source, broker-neutral replacement for Kafka Connect — any-language plugins, embeddable as a Go library, and built for agents and automation. Get a pipeline running in under a minute.',
   favicon: 'img/favicon.ico',
   
   // Set the production url of your site here
@@ -163,8 +163,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Meroxa, Inc.`,
     },
     announcementBar: {
-      id: 'announcement-bar-14', // increment on change
-      content: `Conduit v0.14.0 is here! <a class='cta' href='/changelog/2025-06-13-conduit-0-14-0-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
+      id: 'announcement-bar-16', // increment on change
+      content: `Conduit v0.16.0 is here! <a class='cta' href='/changelog/2026-07-06-conduit-0-16-0-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
       isCloseable: true,
     },
     colorMode: {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -4,24 +4,24 @@ import styles from './styles.module.css';
 
 const FeatureList = [
   {
-    title: 'Simple',
+    title: '60-Second Start',
     img: require('@site/static/img/simple.png').default,
-    description: "Eliminate the multi-step process you go through today. Just download the binary and start building.",
+    description: "Download a single binary and run conduit quickstart to watch a demo pipeline stream records to your console in under a minute — zero configuration.",
   },
   {
-    title: 'Extensible',
+    title: 'Any Language',
     img: require('@site/static/img/scalable.png').default,
-    description: "Conduit connectors give you the ability to pull and push data to any production datastore you need. If a datastore is missing, the simple SDK allows you to extend Conduit where you need it.",
+    description: "Connectors and processors run over gRPC or compile to WASM, so you can write plugins in any language — not just the JVM.",
   },
   {
-    title: 'Real-Time',
+    title: 'Broker-Neutral',
     img: require('@site/static/img/realtime.png').default,
-    description: "Conduit pipelines listen for changes to a database, data warehouse, etc., and allows your data applications to act upon those changes in real-time.",
+    description: "Conduit isn't tied to Kafka. Move data between any source and destination — databases, warehouses, queues, and more — with the same pipeline model.",
   },
   {
-    title: 'Flexible',
+    title: 'Embeddable & Agent-Ready',
     img: require('@site/static/img/flexible.png').default,
-    description: "Run it in a way that works for you; use it as a standalone service or orchestrate it within your infrastructure.",
+    description: "Run it standalone or embed it as a Go library in your own service. Every command supports --json and returns structured, stable error codes, so agents and scripts can drive it directly.",
   },
 ];
 
@@ -41,7 +41,7 @@ const Feature = ({ img, title, description }) => (
 export default function HomepageFeatures() {
   return (
     <div className="pb-10 mt-10 features">
-      <h2 className='text-4xl font-bold pb-10 text-forest-100 text-center'> Deliver real-time event-based data in no time </h2>
+      <h2 className='text-4xl font-bold pb-10 text-forest-100 text-center'>Everything Kafka Connect does — without the JVM or the Kafka lock-in</h2>
       <ul className={clsx(styles['feature-grid'], "gap-3 grid grid-cols-1 lg:grid lg:grid-cols-2 lg:gap-6 lg:space-y-0")}>
         {FeatureList.map((feature) => (
           <Feature {...feature} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ function HeaderSection() {
           <SplitPair data-reversed data-skewed="60:40">
             <Stack className="basis-3/5">
               <h1 className="font-bold text-5xl lg:text-5xl md:text-5xl text-white">
-                Data Integration for Production Data Stores
+                The Open-Source Kafka Connect Replacement
               </h1>
 
               <p className='mt-10 text-white'>

--- a/src/processorgen/specs/avro.decode.json
+++ b/src/processorgen/specs/avro.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/src/processorgen/specs/avro.encode.json
+++ b/src/processorgen/specs/avro.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/src/processorgen/specs/base64.decode.json
+++ b/src/processorgen/specs/base64.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/base64.encode.json
+++ b/src/processorgen/specs/base64.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/clone.json
+++ b/src/processorgen/specs/clone.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "clone",
     "summary": "Clone records.",
-    "description": "Clone all records N times. For each input record, the processor\noutputs the original record plus N clones (for a total of N+1 records). Each clone\nis identical to the original, except the metadata field `clone.index` is\nset to the clone's index (0 for the original, 1 to N for the clones).\n\n**Important:** Add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor if you only want to clone some records.\n\n**Important:** This processor currently only works using the pipeline architecture\nv2, which can be enabled using the flag `--preview.pipeline-arch-v2`.\nUsing it without the flag will result in an error.",
+    "description": "Clone all records N times. For each input record, the processor\noutputs the original record plus N clones (for a total of N+1 records). Each clone\nis identical to the original, except the metadata field `clone.index` is\nset to the clone's index (0 for the original, 1 to N for the clones).\n\n**Important:** Add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor if you only want to clone some records.\n\n**Important:** This processor currently only works using the pipeline architecture\nv2, which can be enabled using the flag `--preview.pipeline-arch-v2`.\nUsing it without the flag will result in an error.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/src/processorgen/specs/error.json
+++ b/src/processorgen/specs/error.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "error",
     "summary": "Returns an error for all records that get passed to the processor.",
-    "description": "Any time a record is passed to this processor it returns an error,\nwhich results in the record being sent to the DLQ if it's configured, or the pipeline stopping.\n\n**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor, otherwise all records will trigger an error.",
+    "description": "Any time a record is passed to this processor it returns an error,\nwhich results in the record being sent to the DLQ if it's configured, or the pipeline stopping.\n\n**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor, otherwise all records will trigger an error.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/src/processorgen/specs/field.convert.json
+++ b/src/processorgen/specs/field.convert.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/field.exclude.json
+++ b/src/processorgen/specs/field.exclude.json
@@ -8,7 +8,7 @@
     "parameters": {
       "fields": {
         "default": "",
-        "description": "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/field.rename.json
+++ b/src/processorgen/specs/field.rename.json
@@ -8,7 +8,7 @@
     "parameters": {
       "mapping": {
         "default": "",
-        "description": "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/field.set.json
+++ b/src/processorgen/specs/field.set.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/filter.json
+++ b/src/processorgen/specs/filter.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "filter",
     "summary": "Acknowledges all records that get passed to the filter.",
-    "description": "Acknowledges all records that get passed to the filter, so\nthe records will be filtered out if the condition provided to the processor is\nevaluated to `true`.\n\n**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor, otherwise all records will be filtered out.",
+    "description": "Acknowledges all records that get passed to the filter, so\nthe records will be filtered out if the condition provided to the processor is\nevaluated to `true`.\n\n**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor, otherwise all records will be filtered out.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/src/processorgen/specs/json.decode.json
+++ b/src/processorgen/specs/json.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/json.encode.json
+++ b/src/processorgen/specs/json.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/split.json
+++ b/src/processorgen/specs/split.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/unwrap.debezium.json
+++ b/src/processorgen/specs/unwrap.debezium.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.debezium",
-    "summary": "Unwraps a Debezium record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
-    "description": "In this processor, the wrapped (Debezium) record replaces the wrapping record (being processed) \ncompletely, except for the position.\n\nThe Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.",
+    "summary": "Unwraps a Debezium record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
+    "description": "In this processor, the wrapped (Debezium) record replaces the wrapping record (being processed) \ncompletely, except for the position.\n\nThe Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/src/processorgen/specs/unwrap.kafkaconnect.json
+++ b/src/processorgen/specs/unwrap.kafkaconnect.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.kafkaconnect",
-    "summary": "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
-    "description": "This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).\n\nThe input record's payload is replaced with the Kafka Connect record.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.",
+    "summary": "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
+    "description": "This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).\n\nThe input record's payload is replaced with the Kafka Connect record.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {
@@ -46,7 +46,7 @@
   "examples": [
     {
       "summary": "Unwrap a Kafka Connect record",
-      "description": "This example shows how to unwrap a Kafka Connect record.\n\nThe Kafka Connect record is serialized as a JSON string in the `.Payload.After` field (raw data).\nThe Kafka Connect record's payload will replace the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload.\n\nWe also see how the key is unwrapped too. In this case, the key comes in as structured data.",
+      "description": "This example shows how to unwrap a Kafka Connect record.\n\nThe Kafka Connect record is serialized as a JSON string in the `.Payload.After` field (raw data).\nThe Kafka Connect record's payload will replace the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload.\n\nWe also see how the key is unwrapped too. In this case, the key comes in as structured data.",
       "config": {
         "field": ".Payload.After"
       },

--- a/src/processorgen/specs/unwrap.opencdc.json
+++ b/src/processorgen/specs/unwrap.opencdc.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.opencdc",
-    "summary": "Unwraps an [OpenCDC record](https://conduit.io/docs/using/opencdc-record) saved in one of the record's fields.",
-    "description": "The `unwrap.opencdc` processor is useful in situations where a record goes through intermediate\nsystems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is part of the payload\nread from the intermediate system and needs to be unwrapped before being written.\n\nNote: if the wrapped [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.",
+    "summary": "Unwraps an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) saved in one of the record's fields.",
+    "description": "The `unwrap.opencdc` processor is useful in situations where a record goes through intermediate\nsystems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is part of the payload\nread from the intermediate system and needs to be unwrapped before being written.\n\nNote: if the wrapped [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },
@@ -40,8 +40,8 @@
   },
   "examples": [
     {
-      "summary": "Unwrap an [OpenCDC record](https://conduit.io/docs/using/opencdc-record)",
-      "description": "In this example we use the `unwrap.opencdc` processor to unwrap the [OpenCDC record](https://conduit.io/docs/using/opencdc-record) found in the record's `.Payload.After` field.",
+      "summary": "Unwrap an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)",
+      "description": "In this example we use the `unwrap.opencdc` processor to unwrap the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) found in the record's `.Payload.After` field.",
       "config": {
         "field": ".Payload.After"
       },

--- a/src/processorgen/specs/webhook.http.json
+++ b/src/processorgen/specs/webhook.http.json
@@ -77,13 +77,13 @@
       },
       "response.body": {
         "default": ".Payload.After",
-        "description": "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },
       "response.status": {
         "default": "",
-        "description": "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.0/connector.yaml
@@ -134,7 +134,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.1/connector.yaml
@@ -132,7 +132,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.2/connector.yaml
@@ -132,7 +132,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.3/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-file@v0.10.3/connector.yaml
@@ -132,7 +132,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.0/connector.yaml
@@ -26,7 +26,7 @@ specification:
     - `sdk.record.format`: used to choose the format
     - `sdk.record.format.options`: used to configure the specifics of the chosen format
 
-    See [this article](https://conduit.io/docs/connectors/output-formats) for more
+    See [this article](https://conduitdata.io/docs/connectors/output-formats) for more
     info on configuring the output format.
 
     ### Batching
@@ -328,7 +328,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.1/connector.yaml
@@ -26,7 +26,7 @@ specification:
     - `sdk.record.format`: used to choose the format
     - `sdk.record.format.options`: used to configure the specifics of the chosen format
 
-    See [this article](https://conduit.io/docs/connectors/output-formats) for more
+    See [this article](https://conduitdata.io/docs/connectors/output-formats) for more
     info on configuring the output format.
 
     ### Batching
@@ -326,7 +326,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.2/connector.yaml
@@ -26,7 +26,7 @@ specification:
     - `sdk.record.format`: used to choose the format
     - `sdk.record.format.options`: used to configure the specifics of the chosen format
 
-    See [this article](https://conduit.io/docs/connectors/output-formats) for more
+    See [this article](https://conduitdata.io/docs/connectors/output-formats) for more
     info on configuring the output format.
 
     ### Batching
@@ -326,7 +326,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.3/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-kafka@v0.12.3/connector.yaml
@@ -26,7 +26,7 @@ specification:
     - `sdk.record.format`: used to choose the format
     - `sdk.record.format.options`: used to configure the specifics of the chosen format
 
-    See [this article](https://conduit.io/docs/connectors/output-formats) for more
+    See [this article](https://conduitdata.io/docs/connectors/output-formats) for more
     info on configuring the output format.
 
     ### Batching
@@ -338,7 +338,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.0/connector.yaml
@@ -67,7 +67,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.1/connector.yaml
@@ -67,7 +67,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.2/connector.yaml
@@ -67,7 +67,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.3/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-log@v0.7.3/connector.yaml
@@ -21,7 +21,7 @@ specification:
 
     ### Known issues
 
-    - **Only when using as a [standalone connector](https://conduit.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
+    - **Only when using as a [standalone connector](https://conduitdata.io/docs/core-concepts#standalone-connector)**: Messages larger than 64KB will not be logged when using `log.level` as `info`.
       This is a known issue caused by the default buffer value of `go-plugin`. More information can be found in [this comment](https://github.com/ConduitIO/conduit-connector-log/issues/81#issuecomment-2904224580).
   version: v0.7.3
   author: Meroxa, Inc.
@@ -72,7 +72,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.0/connector.yaml
@@ -270,7 +270,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.1/connector.yaml
@@ -270,7 +270,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.11.2/connector.yaml
@@ -270,7 +270,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.0/connector.yaml
@@ -273,7 +273,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.1/connector.yaml
@@ -273,7 +273,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.12.2/connector.yaml
@@ -273,7 +273,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.13.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.13.0/connector.yaml
@@ -273,7 +273,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.14.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-postgres@v0.14.0/connector.yaml
@@ -268,7 +268,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.0/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.0/connector.yaml
@@ -243,7 +243,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.1/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.1/connector.yaml
@@ -241,7 +241,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.2/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.2/connector.yaml
@@ -241,7 +241,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.3/connector.yaml
+++ b/static/connectors/github.com/ConduitIO/conduit-connector-s3@v0.9.3/connector.yaml
@@ -241,7 +241,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-activemq-artemis@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-activemq-artemis@v0.1.0/connector.yaml
@@ -3,7 +3,7 @@ specification:
   name: activemq
   summary: An ActiveMQ Artemis source and destination plugin for Conduit, written in Go.
   description: |-
-    The ActiveMQ Classic connector is one of [Conduit](https://conduit.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
+    The ActiveMQ Classic connector is one of [Conduit](https://conduitdata.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
 
     It uses the [stomp protocol](https://stomp.github.io/) to connect to ActiveMQ.
 
@@ -278,7 +278,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-activemq-artemis@v0.1.1/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-activemq-artemis@v0.1.1/connector.yaml
@@ -3,7 +3,7 @@ specification:
   name: activemq
   summary: An ActiveMQ Artemis source and destination plugin for Conduit, written in Go.
   description: |-
-    The ActiveMQ Classic connector is one of [Conduit](https://conduit.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
+    The ActiveMQ Classic connector is one of [Conduit](https://conduitdata.io) plugins. The connector provides both a source and a destination connector for [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/).
 
     It uses the [stomp protocol](https://stomp.github.io/) to connect to ActiveMQ.
 
@@ -278,7 +278,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-box@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-box@v0.1.0/connector.yaml
@@ -113,7 +113,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-box@v0.1.1/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-box@v0.1.1/connector.yaml
@@ -113,7 +113,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-chaos@v0.2.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-chaos@v0.2.0/connector.yaml
@@ -3,7 +3,7 @@ specification:
   name: chaos
   summary: A chaos destination connector
   description: |-
-    A [Conduit](https://conduit.io) connector that can be configured to behave in
+    A [Conduit](https://conduitdata.io) connector that can be configured to behave in
     unexpected ways to figure out how Conduit handles it.
 
     ## Modes
@@ -188,7 +188,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-dropbox@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-dropbox@v0.1.0/connector.yaml
@@ -193,7 +193,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-dropbox@v0.1.1/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-dropbox@v0.1.1/connector.yaml
@@ -216,7 +216,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-dynamodb@v0.4.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-dynamodb@v0.4.0/connector.yaml
@@ -226,7 +226,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-google-drive@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-google-drive@v0.1.0/connector.yaml
@@ -105,7 +105,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-http@v0.3.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-http@v0.3.0/connector.yaml
@@ -123,7 +123,7 @@ specification:
       - name: url
         description: |-
           URL is a Go template expression for the URL used in the HTTP request, using Go [templates](https://pkg.go.dev/text/template).
-          The value provided to the template is [opencdc.Record](https://conduit.io/docs/using/opencdc-record),
+          The value provided to the template is [opencdc.Record](https://conduitdata.io/docs/using/opencdc-record),
           so the template has access to all its fields (e.g. .Position, .Key, .Metadata, and so on). We also inject all template functions provided by [sprig](https://masterminds.github.io/sprig/)
           to make it easier to write templates.
         type: string
@@ -181,7 +181,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-http@v0.4.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-http@v0.4.0/connector.yaml
@@ -128,7 +128,7 @@ specification:
       - name: url
         description: |-
           URL is a Go template expression for the URL used in the HTTP request, using Go [templates](https://pkg.go.dev/text/template).
-          The value provided to the template is [opencdc.Record](https://conduit.io/docs/using/opencdc-record),
+          The value provided to the template is [opencdc.Record](https://conduitdata.io/docs/using/opencdc-record),
           so the template has access to all its fields (e.g. .Position, .Key, .Metadata, and so on). We also inject all template functions provided by [sprig](https://masterminds.github.io/sprig/)
           to make it easier to write templates.
         type: string
@@ -191,7 +191,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-influxdb@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-influxdb@v0.1.0/connector.yaml
@@ -182,7 +182,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.0/connector.yaml
@@ -328,7 +328,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.1/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.1/connector.yaml
@@ -328,7 +328,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.2/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mongo@v0.2.2/connector.yaml
@@ -326,7 +326,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.0/connector.yaml
@@ -162,7 +162,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.1/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.1/connector.yaml
@@ -169,7 +169,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.2/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.2/connector.yaml
@@ -169,7 +169,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.3/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.3/connector.yaml
@@ -14,7 +14,7 @@ specification:
     from the configured tables as record snapshots.
 
     In snapshot mode, the record payload consists of
-    [opencdc.StructuredData](https://conduit.io/docs/using/opencdc-record#structured-data),
+    [opencdc.StructuredData](https://conduitdata.io/docs/using/opencdc-record#structured-data),
     with each key being a column and each value being that column's value.
 
     ### Change Data Capture mode
@@ -267,7 +267,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.4/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.1.4/connector.yaml
@@ -14,7 +14,7 @@ specification:
     from the configured tables as record snapshots.
 
     In snapshot mode, the record payload consists of
-    [opencdc.StructuredData](https://conduit.io/docs/using/opencdc-record#structured-data),
+    [opencdc.StructuredData](https://conduitdata.io/docs/using/opencdc-record#structured-data),
     with each key being a column and each value being that column's value.
 
     ### Change Data Capture mode
@@ -69,7 +69,7 @@ specification:
 
     ### Record structure
 
-    Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduit.io/docs/using/opencdc-record):
+    Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduitdata.io/docs/using/opencdc-record):
 
     *   **Operation**: Indicates the type of change (`create`, `update`, `delete`, `snapshot`).
     *   **Payload**:
@@ -79,7 +79,7 @@ specification:
     *   **Position**: Represents the point in the data stream. It's a JSON object containing *either* a `snapshot_position` field *or* a `cdc_position` field, structured as described below.
     *   **Metadata**: Contains standard OpenCDC fields plus:
         *   `mysql.server.id`: (CDC only) The originating MySQL server ID from the replication event header.
-        *   [Key](https://conduit.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduit.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
+        *   [Key](https://conduitdata.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduitdata.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
 
     #### Snapshot Records
 
@@ -296,7 +296,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.2.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-mysql@v0.2.0/connector.yaml
@@ -14,7 +14,7 @@ specification:
     from the configured tables as record snapshots.
 
     In snapshot mode, the record payload consists of
-    [opencdc.StructuredData](https://conduit.io/docs/using/opencdc-record#structured-data),
+    [opencdc.StructuredData](https://conduitdata.io/docs/using/opencdc-record#structured-data),
     with each key being a column and each value being that column's value.
 
     ### Change Data Capture mode
@@ -69,7 +69,7 @@ specification:
 
     ### Record structure
 
-    Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduit.io/docs/using/opencdc-record):
+    Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduitdata.io/docs/using/opencdc-record):
 
     *   **Operation**: Indicates the type of change (`create`, `update`, `delete`, `snapshot`).
     *   **Payload**:
@@ -79,7 +79,7 @@ specification:
     *   **Position**: Represents the point in the data stream. It's a JSON object containing *either* a `snapshot_position` field *or* a `cdc_position` field, structured as described below.
     *   **Metadata**: Contains standard OpenCDC fields plus:
         *   `mysql.server.id`: (CDC only) The originating MySQL server ID from the replication event header.
-        *   [Key](https://conduit.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduit.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
+        *   [Key](https://conduitdata.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduitdata.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
 
     #### Snapshot Records
 
@@ -296,7 +296,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.2.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.2.0/connector.yaml
@@ -334,7 +334,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.3.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.3.0/connector.yaml
@@ -334,7 +334,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.4.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-rabbitmq@v0.4.0/connector.yaml
@@ -349,7 +349,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []

--- a/static/connectors/github.com/conduitio-labs/conduit-connector-snowflake@v0.4.0/connector.yaml
+++ b/static/connectors/github.com/conduitio-labs/conduit-connector-snowflake@v0.4.0/connector.yaml
@@ -363,7 +363,7 @@ specification:
       - name: sdk.record.format
         description: |-
           The format of the output record. See the Conduit documentation for a full
-          list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+          list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
         type: string
         default: opencdc/json
         validations: []


### PR DESCRIPTION
The site was stuck at **v0.14.0**. This brings it current across changelog, docs, and landing copy. **Docusaurus build passes** (no broken links / MDX errors). The positioning copy is a **draft for your review** — before→afters below.

## Changelog (3 backfilled entries)
- `2026-07-04-conduit-0-15-0-release` — the revival stable cut
- `2026-07-04-conduit-0-15-1-release` — graceful SIGTERM drain
- `2026-07-06-conduit-0-16-0-release` — the headline release

Feature→release attribution was **verified against the v0.16.0 tag**: quickstart, `ConduitError`, `--json`, `/readyz`, env-config are v0.16.0; **exit codes, log redaction, and the error-code guard are v0.16.1** (called out in a tip, not listed as v0.16.0 highlights).

## Docs
- **New**: Health & Readiness (`/readyz`,`/healthz`), Exit codes, Structured errors & JSON output
- **Extended**: Getting Started (quickstart fast-path), CLI (`quickstart` + `--json`), Configuration (env-var precedence, `--pipelines`, secrets-in-logs)
- Mirrors the canonical docs in the `conduit` repo.

## Copy — repositioning (please review the wording)
| Field | Before | After |
|---|---|---|
| **title** | Conduit \| Data Integration for Production Data Stores | Conduit \| The Open-Source Kafka Connect Replacement |
| **tagline** | Sync data between your production systems… minimal dependencies… for free. | The open-source, broker-neutral replacement for Kafka Connect — any-language plugins, embeddable as a Go library, and built for agents and automation. Get a pipeline running in under a minute. |
| **feature 1** | Simple | **60-Second Start** (`conduit quickstart`) |
| **feature 2** | Extensible | **Any Language** (gRPC + WASM plugins) |
| **feature 3** | Real-Time | **Broker-Neutral** (not tied to Kafka) |
| **feature 4** | Flexible | **Embeddable & Agent-Ready** (Go lib + `--json`/stable codes) |
| **section h2** | Deliver real-time event-based data in no time | Everything Kafka Connect does — without the JVM or the Kafka lock-in |
| **hero h1** | Data Integration for Production Data Stores | The Open-Source Kafka Connect Replacement |

**Accuracy**: every claim was checked against the code. The "Kafka Connect migration" idea was **dropped** — only a `kafka_connect` *processor* exists, not a `migrate` command — so the copy frames Conduit as the *replacement* without asserting an unbuilt migration tool.

## Notes
- The hero `<h1>` + one section `<h2>` were updated beyond the tagline because the old phrasing sat next to the new cards and would have read as contradictory — easy to revert if you'd rather.
- 4 pre-existing broken *anchors* (on connector-lifecycle / provisioning / processors pages) are unrelated to this PR and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)