### PR TITLE
chore(connectorgen): rewrite conduit.io -> conduitdata.io in generated output

### DIFF
--- a/src/connectorgen/docs.go
+++ b/src/connectorgen/docs.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
@@ -169,15 +170,24 @@ func (cmd *CommandDocs) generateDocPage(
 	defer f.Close()
 
 	fmt.Printf("  💾 Writing %s ...\n", path)
-	return readmegen.Generate(readmegen.GenerateOptions{
+	// Generate into a buffer so we can rewrite legacy conduit.io links (sourced
+	// from upstream connector READMEs) to the current site domain before writing.
+	var buf bytes.Buffer
+	if err := readmegen.Generate(readmegen.GenerateOptions{
 		Data: data{
 			Repository:     repo,
 			Specifications: specifications,
 		},
 		ReadmePath: "./connector-docs-mdx.tmpl",
-		Out:        f,
+		Out:        &buf,
 		FuncMap:    funcMap,
-	})
+	}); err != nil {
+		return err
+	}
+	if _, err := f.Write(rewriteDomain(buf.Bytes())); err != nil {
+		return fmt.Errorf("could not write %s: %w", path, err)
+	}
+	return nil
 }
 
 var funcMap = template.FuncMap{

--- a/src/connectorgen/domain.go
+++ b/src/connectorgen/domain.go
@@ -1,0 +1,33 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "strings"
+
+// The project no longer controls conduit.io; the site is served from
+// conduitdata.io. Upstream connector READMEs and connector.yaml specs still
+// hardcode conduit.io links, so generated output must be rewritten — otherwise a
+// `make generate` would silently reintroduce dead links.
+const (
+	legacyDomain  = "conduit.io"
+	currentDomain = "conduitdata.io"
+)
+
+// rewriteDomain replaces legacy conduit.io references with the current site
+// domain in generated content. Safe because "conduit.io" is not a substring of
+// "conduitdata.io" (no double-rewrite).
+func rewriteDomain(b []byte) []byte {
+	return []byte(strings.ReplaceAll(string(b), legacyDomain, currentDomain))
+}

--- a/src/connectorgen/domain_test.go
+++ b/src/connectorgen/domain_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestRewriteDomain(t *testing.T) {
+	cases := map[string]string{
+		"see https://conduit.io/docs/x":      "see https://conduitdata.io/docs/x",
+		"curl https://conduit.io/install.sh": "curl https://conduitdata.io/install.sh",
+		"no domain here":                     "no domain here",
+		// already-current domain must not be double-rewritten
+		"https://conduitdata.io/docs": "https://conduitdata.io/docs",
+	}
+	for in, want := range cases {
+		if got := string(rewriteDomain([]byte(in))); got != want {
+			t.Errorf("rewriteDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/src/connectorgen/specifications.go
+++ b/src/connectorgen/specifications.go
@@ -122,7 +122,7 @@ func (cmd *CommandSpecifications) Execute(ctx context.Context) error {
 			// Write connector.yaml
 			if yamlContent != nil {
 				connectorYamlPath := filepath.Join(folderPath, "connector.yaml")
-				if err := os.WriteFile(connectorYamlPath, yamlContent, 0644); err != nil {
+				if err := os.WriteFile(connectorYamlPath, rewriteDomain(yamlContent), 0644); err != nil {
 					return fmt.Errorf("failed to write connector.yaml for %s@%s: %w",
 						repo.NameWithOwner, release.TagName, err)
 				}


### PR DESCRIPTION
Follow-up to the conduitdata.io migration (#339). The connector-list docs and connector specs are **generated** by `connectorgen` from upstream connector READMEs that still hardcode `conduit.io`, so a future `make generate` would reintroduce dead links. This teaches the generator to rewrite the domain in its output.

- **`docs.go`** — generate the `.mdx` into a buffer, rewrite `conduit.io`→`conduitdata.io`, then write.
- **`specifications.go`** — rewrite `connector.yaml` bytes before writing.
- **`domain.go`** — shared `rewriteDomain` helper + unit test. Safe: `conduit.io` isn't a substring of `conduitdata.io` (no double-rewrite). Mirrors the existing `github.com`→scarf rewrite in `registry.go`.

Verified: `go build` + `rewriteDomain` unit test pass. A full `make generate` (fetches every connector repo from GitHub) wasn't run here.

The durable fix is upstream (connector READMEs shouldn't hardcode a domain) — this keeps generated output correct until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)