### PR TITLE
docs: connector registry publish flow + trust model (v0.18)

### DIFF
--- a/docs/1-using/5-connectors/3-trust-model.mdx
+++ b/docs/1-using/5-connectors/3-trust-model.mdx
@@ -176,9 +176,12 @@ The verification pipeline described here is implemented and wired into `conduit 
 connectors audit`: index-signature verification, freshness/rollback checks, identity-pinned artifact-signature
 verification, and SLSA provenance binding all run, and installs fail closed by default.
 
-The registry's production key material and the live index are established by a one-time bootstrap ceremony that is being
-finalized ahead of the v0.18 release. Until that completes, an install against a real index fails closed with
-`registry.trust_anchor_expired` — the correct, intended pre-bootstrap behavior (fail closed, never fail open), not a bug.
-The independent index-CI re-verification on the registry repository, and the exact pinned SLSA builder identity, are being
-confirmed alongside the [connector-publish-action](https://github.com/ConduitIO/connector-publish-action) as the bootstrap
-lands.
+The bootstrap ceremony is complete: the production root and freshness anchors are compiled into released builds, and the
+registry serves a signed index at `https://registry.conduitdata.io/index.json` that a released build verifies against
+those anchors (a build with no embedded anchors still fails closed with `registry.trust_anchor_expired`, never fail
+open). Connectors are published to it through the
+[connector-publish-action](https://github.com/ConduitIO/connector-publish-action).
+
+One safeguard is still landing: an independent index-CI re-verification on the registry repository — a second, automated
+re-check of every registration PR, distinct from the client-side verification above — is planned but not yet in place, so
+registrations are human-reviewed in the meantime.

--- a/docs/1-using/5-connectors/3-trust-model.mdx
+++ b/docs/1-using/5-connectors/3-trust-model.mdx
@@ -1,0 +1,184 @@
+---
+title: "The Registry Trust Model"
+---
+
+# The connector registry trust model
+
+When you run `conduit connectors install postgres`, Conduit does not simply download a binary and run it. It verifies —
+cryptographically, before the connector is ever runnable — that the artifact was built and signed by the exact identity
+the registry has pinned for the name `postgres`, that it carries non-forgeable build provenance, and that the registry
+index vouching for all of this is itself authentic and fresh. If any check fails, the install is refused. Nothing is
+trusted on assertion.
+
+This page explains why you can trust an installed connector, and what each layer of verification actually protects
+against. If you are publishing a connector, see [Publishing to the registry](/docs/developing/connectors/publishing) for
+the authoring side.
+
+## The short version
+
+An installed connector is trustworthy because four independent things are all checked before it runs:
+
+1. **The index is authentic.** The registry index is signed with a key compiled into your Conduit binary. Conduit verifies
+   that signature before trusting a single field in the index.
+2. **The connector's signer is the one the registry pinned.** Each connector name pins the specific GitHub workflow
+   identity allowed to sign it. A valid signature by *any other* identity is refused.
+3. **The build is provable.** Each artifact carries SLSA Build L3 provenance binding it to a non-forgeable,
+   GitHub-hosted build process.
+4. **It fails closed.** If the trust anchors or the index are missing, expired, or unverifiable, install refuses — it
+   never falls back to installing something unverified.
+
+## The trust anchors
+
+Two public keys are compiled into every Conduit binary at build time. They are the root of everything else.
+
+- **`root`** — the registry root public key. It authorizes *content*: which connectors exist, which identities may sign
+  them, which versions are published, and which are yanked or revoked.
+- **`freshness`** — a separate, narrowly-scoped key. It may *only* extend the index's `timestamp` and bump its `version`
+  over a byte-identical set of connectors. It exists so an unattended nightly job can keep the index provably fresh
+  without ever touching content. **A freshness signature never authorizes content on its own.**
+
+Both are **ed25519** keys, stored as SPKI PEM. Each is identified by a `keyId` of the form `sha256:<hex(SHA256(SPKI-DER))>`
+— the SHA-256 fingerprint of the DER-encoded public key. Conduit and the registry's signing tooling derive `keyId`
+through the same shared function, so a client and the index can never disagree about which key is which.
+
+Critically, **trust anchors are fixed at build time and are never updated at runtime.** There is no "rotation statement"
+that a running Conduit fetches and applies — such a mechanism would let a compromised old key forge a rotation to an
+attacker's key. A new root key reaches you only when you upgrade to a Conduit build compiled with it.
+
+## The signed index
+
+The registry is a single signed JSON document served from `https://registry.conduitdata.io/index.json`. There is no
+hosted service, no login, no click-through. The index records, per connector: its versions, each version's per-platform
+artifacts (URL, `sha256`, size), minimum Conduit and protocol versions, the publisher's pinned identity, and any yanks
+or revocations.
+
+The document is an envelope of `payload` plus a `signatures[]` array. **Everything a client trusts lives inside the
+signed `payload`** — names, pinned identities, artifact digests, revocations, even the schema version. The only bytes
+outside the signature are the signatures themselves. When Conduit verifies the index it:
+
+1. Rejects any duplicate JSON key at any nesting level (a duplicate-key parser differential is a signature-bypass
+   primitive, so it is refused before anything else).
+2. Canonicalizes the `payload` with JCS (RFC 8785) and checks each signature against the compiled-in anchors.
+3. **Accepts on a valid `root` signature.** Accepts a `freshness`-only signature *only* when the payload's connectors are
+   byte-identical to the last content this machine verified under a `root` signature.
+4. Only *after* the signature verifies does it interpret any field — so a client never has to trust `schemaVersion` (or
+   anything else) to decide *how* to check the signature. Verification is the same regardless of payload shape.
+
+On top of authenticity, Conduit checks **freshness and rollback**: it refuses an index whose timestamp is older than the
+max-staleness window (default 7 days), and refuses one whose version is below the highest it has already verified on this
+machine. These defeat a compromised CDN that replays a stale index still listing a since-yanked version as good.
+
+## Per-connector identity pinning
+
+This is the decision the whole model hangs on. Keyless signing proves *who* signed an artifact — an OIDC issuer plus a
+workflow identity. It does **not**, by itself, prove that *who* is the entity allowed to publish the name `postgres`.
+Without pinning, anyone who forks the publish workflow into their own repository could produce a perfectly valid,
+transparency-logged signature for a connector named `postgres` and earn a green "verified" badge.
+
+So the index records, per connector name, the publisher's `expectedOIDCIssuer` and `expectedIdentityPattern` — a
+fully-anchored regular expression pinning that connector's own publish workflow (its repository, workflow file, and ref
+pattern). At install time, Conduit verifies the artifact's signature with the certificate identity constrained to that
+pinned pattern. **A valid signature by any other identity is refused** with `registry.identity_mismatch` — a distinct
+outcome from "no signature at all" (`registry.unsigned`).
+
+The pattern must be tight. Conduit defensively re-validates it before ever using it to accept a signature: an
+un-anchored or overly-broad pattern (for example `^.*$`, which would collapse pinning to "any signature at all") is
+refused as `registry.identity_pattern_too_loose`, independent of whether index review caught it. "Verified" is always
+*derived* from a signature by the pinned identity plus valid provenance — it is never a hand-set field.
+
+## Keyless signing and SLSA provenance
+
+Connector artifacts are signed with **cosign keyless signing** through Sigstore's Fulcio CA, using the publishing
+workflow's GitHub OIDC identity. There are no long-lived private keys anywhere — nothing to custody, leak, or rotate. The
+identity that signed is exactly the CI workflow that ran, recorded in a public transparency log.
+
+Each artifact also carries **SLSA Build L3 provenance**, generated by `slsa-framework/slsa-github-generator` running as
+an isolated build process a compromised build job cannot impersonate. Beyond checking the attestation's signature,
+Conduit confirms:
+
+- the provenance's `subject` digest matches the exact bytes it just downloaded (not merely that *some* valid provenance
+  exists for the version), and
+- the attestation's `builder.id` matches the single expected SLSA generator identity Conduit is compiled to require —
+  proving the artifact was built by the pinned, non-forgeable, GitHub-hosted generator, not unrelated build infra.
+
+A signature-only artifact with no provenance is refused: production installs require both.
+
+## What `install` verifies, and in what order
+
+`conduit connectors install <name>` runs the same verification code (`pkg/registry/index.Verify` and the identity-pinned
+trust core) that the registry's own index CI runs — there is no divergent "lighter" client path. In order:
+
+1. **Fetch and verify the signed index** (signature against the compiled-in anchors), then check it is fresh and not
+   rolled back — before trusting any field.
+2. **Resolve `<name>[@version]` by exact match.** A typo is a hard `registry.connector_not_found`, never a fuzzy
+   nearest-match install. If the publisher is revoked, refuse; if a pinned version is yanked, refuse.
+3. **Select the artifact for your OS/arch**, or refuse listing the platforms that are available.
+4. **Download to a private staging directory** and compute the digest from the *actually received* bytes. A mismatch
+   against the index (`registry.corrupt_download`) is corruption detection — integrity against a bad download, not the
+   trust boundary.
+5. **Run the authorization gate:** verify the artifact signature and the SLSA attestation against the name's *pinned*
+   identity, and bind the provenance to the downloaded digest and the expected builder. Any failure deletes the staging
+   directory and refuses.
+6. **Only on full success** is the verified artifact atomically moved into your connectors directory and made runnable.
+
+The verification in step 5 is the authorization gate — not the `sha256`. A checksum proves the bytes match what the index
+claims; it does not prove those bytes are safe. Provenance and an identity-pinned signature are what establish trust.
+
+## Fail-closed by design
+
+The registry never fails open. If the situation is ambiguous, install refuses rather than guess:
+
+- If the fetched index carries **no signature matching any anchor compiled into your build**, install refuses with
+  `registry.trust_anchor_expired` ("upgrade Conduit") and never falls back to a stale cache.
+- If a build is missing its embedded anchors entirely (a defective build), install refuses up front with
+  `registry.trust_anchors_unavailable` ("reinstall Conduit") rather than a confusing generic error.
+- A recognized key whose signature does not actually verify is `registry.index_integrity` — tampering or corruption,
+  refused loudly.
+
+There is exactly one escape hatch, `--allow-unsigned`, and it is a gated control, not a bare flag. It requires interactive
+confirmation (retyping the connector name), hard-refuses in non-interactive, `CI`, or agent (MCP) contexts unless a
+separate, harder-to-reach environment escape hatch is also set, and can be disabled entirely by operator policy. An agent
+or script cannot flip it on with a flag alone, and every unsigned install emits a durable audit event.
+
+## Key rotation
+
+Root and freshness keys can be rotated without stranding already-deployed Conduit binaries. During a rotation window the
+embedded anchor PEM file holds **multiple concatenated `PUBLIC KEY` blocks** — the outgoing and incoming keys both
+trusted — and the index is signed by both keys simultaneously. Every already-deployed binary keeps verifying against the
+key it shipped with until it upgrades; a binary compiled with the new key accepts both. The outgoing key is removed only
+after the retention window, which tracks Conduit's supported-version policy. Because rotation happens by upgrading the
+binary — never through a runtime-fetched statement — a compromised old key can never forge a rotation to an attacker's
+key.
+
+## Error codes
+
+Every refusal is a machine-actionable error code. The security-relevant ones:
+
+| Code | Meaning |
+| --- | --- |
+| `registry.unsigned` | No valid signature for the pinned identity at all. |
+| `registry.identity_mismatch` | A signature verified, but for a different certificate identity than the one pinned. |
+| `registry.identity_pattern_too_loose` | The pinned identity pattern failed tightness validation — refused before use. |
+| `registry.identity_revoked` | The connector's publisher identity has been revoked; every version is refused. |
+| `registry.version_yanked` | The requested version was yanked. |
+| `registry.provenance_invalid` | SLSA provenance failed subject-digest or builder binding. |
+| `registry.index_integrity` | A recognized key's signature failed to verify — tampering or corruption. |
+| `registry.trust_anchor_expired` | No index signature matches any anchor in this build — upgrade Conduit. |
+| `registry.trust_anchors_unavailable` | This build has no usable embedded anchors — reinstall Conduit. |
+| `registry.index_stale` | The index is older than the max-staleness window. |
+| `registry.index_rollback` | The index version is below the highest already verified on this machine. |
+| `registry.corrupt_download` | The downloaded bytes did not match the index's `sha256` (corruption, not trust). |
+| `registry.schema_too_new` | The index schema is newer than this build understands — upgrade Conduit. |
+
+## Current status
+
+The verification pipeline described here is implemented and wired into `conduit connectors install` and `conduit
+connectors audit`: index-signature verification, freshness/rollback checks, identity-pinned artifact-signature
+verification, and SLSA provenance binding all run, and installs fail closed by default.
+
+The registry's production key material and the live index are established by a one-time bootstrap ceremony that is being
+finalized ahead of the v0.18 release. Until that completes, an install against a real index fails closed with
+`registry.trust_anchor_expired` — the correct, intended pre-bootstrap behavior (fail closed, never fail open), not a bug.
+The independent index-CI re-verification on the registry repository, and the exact pinned SLSA builder identity, are being
+confirmed alongside the [connector-publish-action](https://github.com/ConduitIO/connector-publish-action) as the bootstrap
+lands.

--- a/docs/2-developing/0-connectors/9-publishing.mdx
+++ b/docs/2-developing/0-connectors/9-publishing.mdx
@@ -1,0 +1,308 @@
+---
+title: "Publishing to the Registry"
+---
+
+# Publish your connector to the registry
+
+Once your connector is written, tested, and releasing binaries on GitHub, you can publish it to the
+[Conduit connector registry](/docs/using/connectors/trust-model) so that anyone can install it with a single command:
+
+```shell
+conduit connectors install your-connector
+```
+
+Publishing is a supply-chain operation, not a metadata upload. When you publish, a GitHub Actions workflow in your own
+repository builds the connector for every supported platform, signs each artifact **keylessly** with Sigstore/cosign,
+generates **SLSA Build L3 provenance**, and opens a pull request against the registry index. Nothing is trusted on your
+say-so: the registry pins your repository's own publish workflow as the only identity allowed to sign your connector, and
+`conduit connectors install` re-verifies every signature and attestation before the connector is ever runnable.
+
+This page covers how to add the publish workflow to your connector repository. For what those signatures actually protect
+against — and why an installed connector can be trusted — see [The connector registry trust model](/docs/using/connectors/trust-model).
+
+## Prerequisites
+
+Before you publish:
+
+- **Your connector releases binaries on GitHub Releases.** The registry does not host artifacts; it records where they
+  live and how to verify them. Publishing signs the artifacts attached to a tagged release in your repo.
+- **Your `connector.yaml` version matches the release tag.** A tag of `v1.2.0` must correspond to a `connector.yaml`
+  declaring `1.2.0`. A mismatch is rejected — the registry will not record a version that disagrees with the connector's
+  own manifest.
+- **A `REGISTRY_INDEX_PR_TOKEN` repository secret.** The final job opens a pull request against
+  `ConduitIO/conduit-connector-registry`. Provide a token (a fine-grained PAT or a GitHub App token) with **contents:
+  write** and **pull-requests: write** scoped to the index repository. This is the only long-lived secret the flow needs
+  — there are no signing keys to custody, because signing is keyless (see below).
+
+:::note
+
+You do **not** create or store any cosign private key. Signing uses your workflow's GitHub OIDC identity through
+Sigstore's Fulcio CA — there is no key material to leak, rotate, or protect. The `REGISTRY_INDEX_PR_TOKEN` only authorizes
+opening the index PR; it plays no part in signing.
+
+:::
+
+## Add the publish workflow
+
+Copy the reference workflow into your connector repository at `.github/workflows/publish.yml`, then adjust the
+`build-command`, the `min-conduit-version` / `min-protocol-version`, the `connector-name`, and the `repository` for your
+connector. It triggers on a version-tag push and runs three jobs.
+
+### The three-job shape
+
+The flow is deliberately three jobs, in order, because each stage needs a different execution shape:
+
+1. **`build`** — for every `(os, arch)` pair, build the artifact and `cosign sign-blob` it keylessly via GitHub OIDC (no
+   stored keys). Upload the artifact and its `.sigstore.json` bundle to the GitHub Release. This job calls
+   `ConduitIO/connector-publish-action` as **composite steps inside your own job** — this is load-bearing (see [Why
+   composite, not reusable](#why-composite-not-reusable)).
+2. **`provenance`** — generate SLSA Build L3 provenance with `slsa-framework/slsa-github-generator`. This is a **separate,
+   isolated job that calls a reusable workflow**, fed the digests from `build`. SLSA L3 requires the provenance-generating
+   process to be isolated from the build so a compromised build job cannot forge its own provenance — which is the exact
+   opposite shape from job 1, and intentionally so.
+3. **`register`** — call `ConduitIO/connector-publish-action` again (composite, in your own job) to resolve your run's
+   identity, verify the current signed index with the *same* code `conduit connectors install` runs, and open or update a
+   PR against `ConduitIO/conduit-connector-registry`.
+
+### The reference workflow
+
+This is the canonical `docs/reference-publish-workflow.yml` from `ConduitIO/connector-publish-action`. Copy it verbatim
+and change only the marked values.
+
+```yaml
+# Reference publish workflow for a Conduit connector repo.
+#
+# Copy this into <your-connector-repo>/.github/workflows/publish.yml and
+# adjust build-command/min-*-version/repository. Triggered by a version
+# tag push (the workflow's OWN identity — owner/repo/this-file@this-tag —
+# is exactly what becomes the pinned publisher.expectedIdentityPattern on
+# first registration; see README.md "Why composite, not reusable").
+#
+# THREE jobs, in this order, because of the load-bearing constraint in
+# README.md §"Why composite, not reusable" + §"Why SLSA provenance needs
+# the opposite":
+#
+#   1. build   — conduitio/connector-publish-action in mode=build, running
+#                INSIDE this job (composite action: no `uses: .../workflows/
+#                *.yml@ref` job boundary), so the cosign-signing identity is
+#                THIS repo's own workflow_ref. Needs `id-token: write`
+#                (cosign OIDC) and `contents: write` (uploading release
+#                assets).
+#   2. provenance — slsa-framework/slsa-github-generator's REUSABLE
+#                workflow, `needs: build`, fed the build job's digest
+#                output. This MUST be a separate job calling a reusable
+#                workflow (the opposite shape from step 1) — SLSA L3
+#                requires the provenance-generating process to be isolated
+#                from the build process, so a compromised build job cannot
+#                forge its own provenance. Its identity becomes
+#                `builder.id` in the emitted attestation — a DIFFERENT
+#                identity from the cosign SAN above, checking a different
+#                thing (see README).
+#   3. register — conduitio/connector-publish-action again, mode=publish,
+#                `needs: [build, provenance]`, running INSIDE THIS repo's
+#                job again (composite, same identity as step 1 — the
+#                identity that gets pinned/checked is this job's, not the
+#                provenance job's). Takes the provenance bundle URL from
+#                job 2 and opens/updates the index-repo PR.
+
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write   # upload release assets
+  id-token: write    # cosign keyless OIDC + SLSA provenance OIDC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.publish.outputs.artifacts }}
+      resolved-identity: ${{ steps.publish.outputs.resolved-identity }}
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # The Action uploads signed assets with `gh release upload`, which does
+      # NOT create the release. If your repo also has a goreleaser release.yml
+      # on the same tag, the two race with no ordering — create the release
+      # here if absent (idempotent), and set goreleaser `release.mode:
+      # keep-existing` so neither workflow fails on, or deletes, the other's
+      # assets. Safe to keep even without goreleaser.
+      - name: Ensure the release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag \
+            --title "$TAG" --generate-notes \
+            || echo "release $TAG already exists — nothing to create"
+
+      - name: Build + cosign-sign the artifact matrix
+        id: publish
+        uses: ConduitIO/connector-publish-action@v1
+        with:
+          mode: build
+          connector-name: postgres
+          version: ${{ github.ref_name }}
+          # Runs once per (os, arch) cell with GOOS/GOARCH/OUTPUT_PATH set.
+          # Replace with your own build (goreleaser, make, a wrapper script
+          # — anything that honors these three env vars).
+          build-command: |
+            CGO_ENABLED=0 go build -o "$OUTPUT_PATH" ./cmd/connector
+
+      # slsa-github-generator's generic generator needs base64-encoded
+      # sha256 subject digests in ITS OWN input shape — derive that
+      # separately from this Action's artifacts output (a one-line jq,
+      # kept here rather than inside the Action so this repo's workflow
+      # stays the single place that knows the generator's exact input
+      # contract, which the Action does not need to depend on).
+      - name: Format subjects for the SLSA generator
+        id: hash
+        run: |
+          echo "hashes=$(echo '${{ steps.publish.outputs.artifacts }}' | \
+            jq -r '[.[] | "\(.sha256)  \(.url | split("/") | last)"] | join("\n")' | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read     # required by the generator to read the build job's workflow run
+      id-token: write   # its own OIDC identity — THIS becomes builder.id
+      contents: write   # uploads the provenance attestation as a release asset
+    # Pin this to a specific, reviewed tag — this ref IS
+    # pkg/registry/trust.ExpectedBuilderID's expected value. Changing it is
+    # a breaking change for every already-registered connector identity;
+    # see connector-publish-action's own drift-guard test
+    # (test/canary/generator_ref_test.go) that fails loudly at PR time if
+    # this ref ever drifts from the conduit-pinned constant.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hashes }}
+      upload-assets: true
+
+  register:
+    needs: [build, provenance]
+    permissions:
+      contents: read
+      id-token: write   # this job's OWN cosign identity must resolve the same as `build`'s (composite action, same repo/workflow — only the ref differs if this is a separate workflow file, which it should not be)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Open/update the index-repo PR
+        uses: ConduitIO/connector-publish-action@v1
+        with:
+          mode: publish
+          connector-name: postgres
+          version: ${{ github.ref_name }}
+          # The build artifacts from job 1 — required because build and publish
+          # are separate jobs (a step output can't cross a job boundary).
+          artifacts-json: ${{ needs.build.outputs.artifacts }}
+          min-conduit-version: '0.15.0'
+          min-protocol-version: '0.9.0'
+          repository: https://github.com/ConduitIO/conduit-connector-postgres
+          # Only needed the FIRST time this connector is registered — a
+          # human-authored, tag-scoped fragment. Omit on every subsequent
+          # version bump (routing.Decide ignores it once the name exists).
+          first-registration-identity-ref-pattern: 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+'
+          provenance-bundle-url: ${{ needs.provenance.outputs.provenance-bundle-url }}
+          index-repo-token: ${{ secrets.REGISTRY_INDEX_PR_TOKEN }}
+```
+
+## Why composite, not reusable
+
+This is the single most important thing to get right, and getting it backwards silently breaks the entire trust model.
+
+`ConduitIO/connector-publish-action` is a **composite action**. You invoke it with `uses:` steps **inside your own job**
+(as `build` and `register` do above). You must **never** call it as a `workflow_call` reusable workflow.
+
+The reason is how GitHub OIDC identity works. When your workflow signs an artifact keylessly, the signing certificate's
+identity (its SAN) is your run's `job_workflow_ref` — for example
+`ConduitIO/conduit-connector-postgres/.github/workflows/publish.yml@refs/tags/v1.2.0`. That value is exactly what the
+registry pins, per connector name, as `publisher.expectedIdentityPattern`. It is the answer to "which repository and
+workflow is allowed to publish under this name."
+
+- With a **composite action**, its steps run inside *your* job. `job_workflow_ref` stays *your* repository's workflow
+  file and ref. The pinned identity is yours, and only your repository can produce a signature that matches it.
+- With a **reusable workflow** (`jobs.<id>.uses: org/repo/.github/workflows/x.yml@ref`), `job_workflow_ref` — and
+  therefore the certificate SAN — resolves to **the reusable workflow's own repo and ref**, not yours. Every connector
+  that called it would sign with the *identical* identity. Per-connector identity pinning would have nothing real to pin:
+  a legitimate publish and an attacker's fork would be cryptographically indistinguishable — "anyone who can call the
+  shared workflow is verified."
+
+That is why the signing steps are a composite action and only the SLSA provenance job is a reusable workflow. The
+provenance job wants the opposite property — an isolated builder identity that a compromised build job cannot impersonate
+— which is precisely what a reusable workflow provides. The two identities check two different things:
+
+| | Identity | Answers |
+| --- | --- | --- |
+| cosign SAN (composite, your repo) | your connector repo's own publish workflow | "is this repo/workflow authorized to publish under this name?" |
+| SLSA `builder.id` (reusable generator) | the pinned `slsa-github-generator` ref | "was this genuinely built by a non-forgeable, GitHub-hosted process?" |
+
+:::caution
+
+Do not restructure `publish.yml` to call the publish action as a reusable workflow, and do not move the signing steps into
+a shared workflow you `uses:` from multiple connectors. Either change repoints your signing identity away from your own
+repository and will make your legitimate publishes fail identity verification.
+
+:::
+
+## First registration vs. version bump
+
+The registry distinguishes two kinds of index PR, gated very differently. Your workflow is the same either way — the
+`register` job routes automatically based on whether your connector name already exists in the verified index.
+
+- **First registration of a name** (or any later change to its pinned identity — an org move, a workflow rename). This is
+  the actual root-of-trust decision: it records *which* identity may sign your connector forever after. It is **always
+  human-reviewed and never auto-merged**, first-party connectors included. This is when the
+  `first-registration-identity-ref-pattern` you supplied is used to build the pinned pattern. A maintainer confirms the
+  identity really belongs to your connector before merging.
+- **A version bump of an already-registered name**, signed by its already-pinned identity. This is low-touch: the
+  `register` job re-verifies the new artifacts against the identity *already committed* in the index (never one the same
+  PR is trying to introduce), and the PR is confined to adding new `versions[]` entries. It cannot register a new name or
+  repoint an existing name's identity — structurally, not by convention.
+
+Omit `first-registration-identity-ref-pattern` on version bumps; it is only consulted on the first registration.
+
+## What happens when you tag a release
+
+End to end, from your side and the registry's:
+
+1. **You push a version tag** (`git tag v1.2.0 && git push origin v1.2.0`). The `build` job compiles and keyless-signs
+   each platform artifact and uploads it plus its Sigstore bundle to the GitHub Release.
+2. **The `provenance` job** generates SLSA L3 provenance over those artifacts.
+3. **The `register` job** verifies the current signed index, resolves your run's identity, and opens (or updates) a PR
+   against `ConduitIO/conduit-connector-registry`.
+4. **A maintainer reviews the PR.** A first registration is reviewed as an identity decision; a version bump is a
+   mechanical re-verification. The registry never records an assertion it has not itself re-checked.
+5. **On merge, the index is re-signed** with the registry root key and served from
+   `https://registry.conduitdata.io/index.json`.
+6. **Users install it.** `conduit connectors install your-connector` fetches the signed index, verifies its signature,
+   verifies your artifact's signature and provenance against your pinned identity, and only then makes the connector
+   runnable.
+
+## Notes and troubleshooting
+
+- **The `build-command` receives `GOOS`, `GOARCH`, and `OUTPUT_PATH`.** Your build must honor all three and write the
+  binary to `OUTPUT_PATH`. Anything that does that works — `goreleaser`, `make`, a shell wrapper.
+- **If you also use goreleaser on the same tag**, keep the `Ensure the release exists` step and set goreleaser's
+  `release.mode: keep-existing` so the two workflows don't race to create or delete each other's release assets.
+- **Pin the SLSA generator to the exact reviewed tag** shown in the reference workflow. That ref is checked against a
+  constant compiled into Conduit; a drift makes every connector's provenance fail to verify.
+- **A fork cannot publish under your name.** If someone forks your repository and tags a release, their run's identity is
+  their fork's, which does not match your pinned `expectedIdentityPattern`. The `register` job's own preflight fails in
+  *their* CI before any index PR is opened; and even a hand-crafted PR is refused by index review and, ultimately, by
+  every user's install-time re-verification.
+
+:::note
+
+`ConduitIO/connector-publish-action` and the registry index repository are new supply-chain infrastructure and are still
+being finalized ahead of the v0.18 release. The workflow shape and identity model on this page are stable; the exact
+action version tag and the pinned SLSA generator ref may be confirmed as the bootstrap completes. Check the
+[connector-publish-action README](https://github.com/ConduitIO/connector-publish-action) for the current pinned versions
+before you copy the workflow.
+
+:::

--- a/docs/2-developing/0-connectors/9-publishing.mdx
+++ b/docs/2-developing/0-connectors/9-publishing.mdx
@@ -299,9 +299,9 @@ End to end, from your side and the registry's:
 
 :::note
 
-`ConduitIO/connector-publish-action` and the registry index repository are new supply-chain infrastructure and are still
-being finalized ahead of the v0.18 release. The workflow shape and identity model on this page are stable; the exact
-action version tag and the pinned SLSA generator ref may be confirmed as the bootstrap completes. Check the
+`ConduitIO/connector-publish-action` is available and pinned at `@v1`; the reference workflow pins the
+`slsa-github-generator` ref that Conduit's trust core is compiled to require. Pin the action to `@v1` (or an exact
+`@v1.x.y`) rather than a branch. Always check the
 [connector-publish-action README](https://github.com/ConduitIO/connector-publish-action) for the current pinned versions
 before you copy the workflow.
 


### PR DESCRIPTION
Two new documentation pages for Conduit's signed connector registry, gating the v0.18 release. Supply-chain security content — accuracy grounded against the merged design docs (`20260713-connector-registry-mvp.md`, `20260714-connector-registry-index-schema.md`), the trust-anchor package docs, and the actual `pkg/registry` implementation.

## Pages

**`docs/2-developing/0-connectors/9-publishing.mdx`** — How-to for connector authors.
- Add `.github/workflows/publish.yml` using the `ConduitIO/connector-publish-action` composite action, invoked as steps **inside the author's own job** — never as a `workflow_call` reusable workflow — with the full explanation of why (the OIDC `job_workflow_ref` becomes the pinned signing identity; a reusable workflow would collapse per-connector pinning).
- The three-job shape: `build` (per-(os,arch), keyless `cosign sign-blob` via GitHub OIDC, upload artifact + `.sigstore.json` to the Release) → `provenance` (SLSA L3 via `slsa-github-generator`, isolated reusable workflow) → `register` (open a PR against `ConduitIO/conduit-connector-registry`).
- Prereqs (`connector.yaml` version matching the tag, `REGISTRY_INDEX_PR_TOKEN`), first-registration (human-reviewed) vs version-bump routing, the tag→PR→review→merge→re-sign→serve flow, and the verbatim canonical reference workflow.

**`docs/1-using/5-connectors/3-trust-model.mdx`** — Explanation for users: "why you can trust an installed connector."
- The two build-time-embedded ed25519 anchors (`root` authorizes content; `freshness` may only extend timestamp/version over byte-identical `connectors[]`), `keyId = sha256:<hex(SHA256(SPKI-DER))>`, the signed static index at `https://registry.conduitdata.io/index.json`, per-connector identity pinning (`expectedIdentityPattern`), keyless cosign + SLSA L3 provenance, the ordered `install` verification pipeline, fail-closed design, key rotation via concatenated PEM blocks, and the registry error-code table.

## Notes

- Requested filename for the trust-model page was `2-trust-model.mdx`, but `2-referencing.mdx` already exists — placed it at the open `3-` slot instead (installing=1, referencing=2, trust-model=3).
- Both pages carry an honest current-status note: the verification pipeline is implemented and wired into `install`/`audit`, but production key material and the live index depend on the bootstrap ceremony being finalized; until then a real install fails closed with `registry.trust_anchor_expired` (intended, not a bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD