### PR TITLE
docs: pipeline validate/lint/dry-run + doctor (0.17)

### DIFF
--- a/docs/1-using/4-pipelines/4-validate-lint-dry-run.mdx
+++ b/docs/1-using/4-pipelines/4-validate-lint-dry-run.mdx
@@ -1,0 +1,257 @@
+---
+title: 'Validate, lint & dry-run'
+sidebar_label: 'Validate, lint & dry-run'
+slug: '/using/pipelines/validate-lint-dry-run'
+---
+
+Before you deploy a pipeline, you can check its configuration without starting
+Conduit. Three offline commands run the same parse, enrich, and validate steps
+that `conduit run` uses at startup, and a fourth command inspects a pipeline that
+is already running:
+
+| Command | Checks | Needs a running Conduit? |
+|---------|--------|--------------------------|
+| `conduit pipelines validate <path>` | Schema and structural correctness (errors only) | No |
+| `conduit pipelines lint <path>` | Everything `validate` does, plus advisory warnings | No |
+| `conduit pipelines dry-run <path>` | Everything `validate` does, plus the enriched graph and plugin resolution | No |
+| `conduit pipelines inspect <PIPELINE_ID>` | Live status and per-stage state of a running pipeline | Yes |
+
+`validate`, `lint`, and `dry-run` are fully offline: they never contact — or
+require — a running Conduit instance. Only `inspect` dials the API.
+
+:::note
+`pipeline` is an alias for `pipelines`, so `conduit pipeline validate ...` and
+`conduit pipelines validate ...` are equivalent.
+:::
+
+## The safety loop
+
+A natural pre-deploy workflow moves from cheapest and strictest to richest:
+
+```shell
+conduit pipelines validate pipelines/orders.yaml   # is it structurally correct?
+conduit pipelines lint     pipelines/orders.yaml   # any advisory warnings?
+conduit pipelines dry-run  pipelines/orders.yaml   # what would run actually load?
+conduit pipelines deploy   pipelines/orders.yaml   # ship it
+```
+
+`<path>` is a single `.yml`/`.yaml` file, or a directory of them (not recursed
+into subdirectories). When you point at a directory, every problem in every file
+is reported — a bad file, or a bad pipeline within a file, never stops the rest
+from being checked.
+
+Every command supports `--json` and exits with a
+[deterministic exit code](/docs/using/other-features/exit-codes): `0` on success,
+`2` on a validation failure.
+
+## `validate` — structural correctness
+
+`validate` runs the offline parse, enrich, and validate steps and reports every
+error it finds. It is errors-only: there are no advisory warnings, so there is
+nothing for a `--strict` flag to escalate (use `lint` for warnings).
+
+```shell
+conduit pipelines validate pipelines/orders.yaml
+```
+
+Each finding is reported with a stable error code, the failing config path, and a
+suggested fix:
+
+```text
+✗ pipelines/orders.yaml
+  config.field_required   /connectors/0/plugin
+    connector "pg-source": "plugin" is mandatory
+    → set connectors[0].plugin (e.g. "builtin:postgres")
+
+Summary: 1 files · 0 passed · 1 failed · 1 problems
+Fix the ✗ items above, then re-run.
+```
+
+A valid file prints a `✓` line per file and exits `0`.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Emit the machine-readable result envelope instead of the rendered report. |
+| `-q`, `--quiet` | Suppress passing/OK lines and progress chrome; print only failures and the summary. |
+| `--no-color` | Disable colored/glyph output even on a color-capable terminal. |
+
+### Exit codes
+
+- `0` — every pipeline is valid.
+- `2` — at least one pipeline is invalid, or the path could not be resolved.
+
+## `lint` — advisory warnings
+
+`lint` runs everything `validate` checks, and additionally reports the parser's
+advisory warnings — deprecated or renamed fields, unrecognized fields, and
+pipeline config version fallbacks — each located by line and column.
+
+```shell
+conduit pipelines lint pipelines/orders.yaml
+```
+
+Warnings are advisory. A file with only warnings still exits `0`:
+
+```text
+⚠ pipelines/orders.yaml
+  ⚠ deprecated field (line 12:3)
+    "settings.foo" is deprecated
+    → use "settings.bar" instead
+
+Summary: 1 files · 0 passed · 1 warned · 0 failed · 0 errors · 1 warnings
+```
+
+Validation errors always fail (exit `2`). When a file has both an error and a
+warning, the error dominates and the run exits `2`, but both are rendered.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--strict` | Treat advisory warnings as failures (exit `2`). |
+| `--json` | Emit the machine-readable result envelope. |
+| `-q`, `--quiet` | Print only warnings, failures, and the summary. |
+| `--no-color` | Disable colored/glyph output. |
+
+Use `--strict` in CI when you want a warning-free config to be a hard gate:
+
+```shell
+conduit pipelines lint ./pipelines --strict
+```
+
+### Exit codes
+
+- `0` — no errors (warnings are allowed).
+- `2` — any validation error, or (with `--strict`) any warning.
+
+## `dry-run` — the enriched graph
+
+`dry-run` runs everything `validate` checks, then reports the fully-enriched
+pipeline graph that `conduit run` would actually load: final connector and
+processor IDs, injected dead-letter-queue defaults, and worker counts. This is
+what makes visible the parts of a config that Conduit fills in for you.
+
+```shell
+conduit pipelines dry-run pipelines/orders.yaml
+```
+
+```text
+✓ pipelines/orders.yaml
+  pipeline orders
+    source      orders:pg-source         builtin:postgres
+    destination orders:s3-sink           builtin:s3
+    DLQ         builtin:file
+
+Summary: 1 files · 1 passed · 0 failed · 0 problems
+```
+
+### Plugin resolution
+
+With `--resolve-plugins` (on by default), `dry-run` also checks that every
+referenced **builtin** plugin exists. An unknown builtin plugin fails with
+`connector.plugin_not_found` and exits `2`.
+
+Standalone (non-builtin) plugin references are left **advisory** — they are not
+statically verifiable because the plugin binary isn't loaded during an offline
+dry-run, so a standalone reference is never a false failure. Turn resolution off
+with `--resolve-plugins=false`:
+
+```shell
+conduit pipelines dry-run ./pipelines --resolve-plugins=false
+```
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--resolve-plugins` | Check that referenced builtin plugins exist (default `true`; standalone plugins stay advisory). |
+| `--json` | Emit the machine-readable result envelope. |
+| `-q`, `--quiet` | Print only problems and the summary. |
+| `--no-color` | Disable colored/glyph output. |
+
+### Exit codes
+
+- `0` — the config is valid and all builtin plugin references resolve.
+- `2` — a validation error or an unknown builtin plugin reference.
+
+## `inspect` — a running pipeline
+
+`inspect` is the one online command in this group. It reports the live
+operational state of a pipeline registered in a running Conduit: its current
+[status](/docs/using/pipelines/statuses) (running, stopped, degraded,
+recovering), any error, and a per-stage summary of its sources, destinations, and
+dead-letter queue. It is the CLI peer of the MCP `inspect_pipeline` tool.
+
+```shell
+conduit pipelines inspect orders
+```
+
+```text
+Pipeline orders  [running]
+  name: orders
+  source       pg-source                builtin:postgres
+  destination  s3-sink                  builtin:s3
+  DLQ          builtin:file
+```
+
+Unlike `validate`, `lint`, and `dry-run`, this command requires a running Conduit
+and dials its API, so it accepts the standard API-address flags. Use
+[`conduit pipelines list`](/docs/cli) to see pipeline IDs, and
+`conduit pipelines describe` for the full static configuration.
+
+### Flags
+
+`inspect` takes the standard API-connection flags and `--json`. It has no
+positional flags of its own beyond the pipeline ID argument.
+
+### Exit codes
+
+- `0` — the pipeline was found and inspected.
+- `2` — the pipeline does not exist (`not_found`).
+- `3` — no running Conduit was reachable.
+
+## JSON output
+
+Every command supports `--json`, emitting the shared result envelope so scripts
+and agents can branch without parsing rendered text:
+
+```json
+{
+  "command": "pipelines.validate",
+  "ok": false,
+  "summary": { "files": 1, "pipelines": 0, "errors": 1, "warnings": 0 },
+  "result": {
+    "files": [
+      {
+        "path": "pipelines/orders.yaml",
+        "ok": false,
+        "pipelines": [],
+        "findings": [
+          {
+            "severity": "error",
+            "code": "config.field_required",
+            "message": "connector \"pg-source\": \"plugin\" is mandatory",
+            "configPath": "/connectors/0/plugin",
+            "suggestion": "set connectors[0].plugin (e.g. \"builtin:postgres\")"
+          }
+        ]
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+- `lint` findings carry `severity: "warning"` and, for warnings, `line` and
+  `column`.
+- `dry-run` adds an `enriched` array to each file report describing the graph
+  `conduit run` would load.
+- `inspect` returns a `result` object with the live `pipeline`, its `connectors`,
+  and its `dlq`.
+
+See [Structured errors & JSON output](/docs/using/other-features/structured-errors)
+for the full envelope contract.
+
+![scarf pixel conduit-site-docs-using-pipelines](https://static.scarf.sh/a.png?x-pxid=4f41012a-be75-4b82-8112-86a7cb40f98a)

--- a/docs/1-using/7-other-features/11-doctor.mdx
+++ b/docs/1-using/7-other-features/11-doctor.mdx
@@ -1,0 +1,166 @@
+---
+title: 'conduit doctor'
+sidebar_label: 'conduit doctor'
+slug: '/using/other-features/doctor'
+---
+
+`conduit doctor` runs a set of offline, non-destructive checks against your
+Conduit configuration and environment and answers one question: **would
+`conduit run` succeed here?** It factors out the exact primitives the runtime
+uses at startup — config validation, database open and ping, address binding,
+plugin directory scan — and runs each as an isolated probe. It never boots a
+Runtime and leaves no files behind.
+
+This is distinct from the running server's
+[`/healthz` and `/readyz` probes](/docs/using/other-features/health-and-readiness),
+which answer "is the running engine serving?". `doctor` is a pre-flight; the
+probes are for a process that is already up.
+
+```shell
+conduit doctor
+```
+
+```text
+Config
+  ✓ config.resolve      conduit.yaml found at ./conduit.yaml
+  ✓ config.validate     configuration is valid
+Store
+  ✗ store.reachable     cannot open badger store at ./conduit.db
+                        └ db.badger.path
+                        → Check the directory exists and is writable, or set db.badger.path.
+Network
+  ✗ network.grpc        address :8084 is already in use
+                        └ api.grpc.address
+                        → Stop the process holding it, or set api.grpc.address to a free port.
+Plugins
+  ⚠ plugins.connectors_dir  ./connectors not found — built-ins still available
+  ✓ plugins.builtin         built-in connectors and processors available
+
+Summary: 4 passed · 1 warnings · 2 failed
+✗ items failed. Fix them, then re-run `conduit doctor`.
+```
+
+`doctor` accepts the same config-affecting flags as `conduit run` (`--db.badger.path`,
+`--api.grpc.address`, `--connectors.path`, and so on), so it checks exactly the
+configuration `run` would use. Results are grouped by category — Config, Store,
+Network, Plugins, Engine — and each `✗` carries the failing config path (`└`) and
+a suggested fix (`→`). Glyphs fall back to `[OK]`/`[!]`/`[X]` when the output is
+not a TTY or `--no-color` is set.
+
+## What it checks
+
+| Check | Question it answers | Verdict on trouble |
+|-------|--------------------|--------------------|
+| `config.resolve` | Was a config file found and parsed? | `warn` if defaults were used |
+| `config.validate` | Is the resolved configuration valid? | `fail` on a bad field (exit `2`) |
+| `store.reachable` | Can the configured database be opened and pinged? | `warn` for in-memory; `fail` if it can't open (exit `3`) |
+| `network.grpc` | Is the gRPC API address free to bind? | `fail` on `EADDRINUSE` (exit `3`) |
+| `network.http` | Is the HTTP API address free to bind? | `fail` on `EADDRINUSE` (exit `3`) |
+| `plugins.connectors_dir` | Is the standalone connectors directory readable? | `warn` if missing (built-ins still work) |
+| `plugins.processors_dir` | Is the standalone processors directory readable? | `warn` if missing |
+| `plugins.builtin` | Is the built-in plugin registry populated? | `fail` if empty |
+| `engine.reachable` | Is a running Conduit API reachable? | `warn` by default; `fail` with `--require-server` |
+| `plugins.standalone_compat` | Do standalone plugin binaries dispense correctly? | `--deep` only; runs each in an isolated subprocess |
+
+A missing plugin directory is deliberately a **warning**, not a failure: built-in
+connectors and processors are always available, so a CI machine without a
+`./connectors` directory is not a broken environment. `engine.reachable` is a
+warning by default because `doctor` is an offline preflight — you usually run it
+*before* there is a server to reach.
+
+Every check is wrapped so that a check which errors, panics, or hangs becomes a
+`fail` (with an `internal.error` code) rather than crashing or blocking the run.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Emit the machine-readable result envelope instead of the rendered report. |
+| `--check <name>` | Run only the named check. Repeatable. See the check names in the table above (or `conduit doctor --help`). |
+| `--deep` | Also run `plugins.standalone_compat`, which dispenses standalone connector plugin binaries in an isolated subprocess. |
+| `--require-server` | Fail (instead of warn) if the Conduit API server isn't reachable. |
+| `-q`, `--quiet` | Suppress passing checks; print only warnings, failures, and the summary. |
+| `--no-color` | Disable colored output. |
+
+Plus the config-affecting flags shared with `conduit run` (`--db.badger.path`,
+`--api.grpc.address`, `--connectors.path`, …).
+
+Passing an unknown `--check` name fails the command and lists the valid names.
+Selecting `--check plugins.standalone_compat` without `--deep` is likewise
+rejected — that check only runs under `--deep`.
+
+## Exit codes
+
+`doctor` uses the standard
+[deterministic exit codes](/docs/using/other-features/exit-codes). Warnings never
+fail the process; only a `✗` does, and the exit code is the worst failing check's
+classification:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Every check passed (warnings are allowed). |
+| `2` | A check found invalid configuration. |
+| `3` | A required dependency — the database, a network address, or (with `--require-server`) the API server — is unreachable. |
+
+Precedence is environment (`3`) over validation (`2`) over runtime (`1`), so a run
+with both a bad config field and a port already in use exits `3`.
+
+## JSON output
+
+`--json` emits the shared result envelope. The `result` object carries the full
+list of check results; the `summary` counts them:
+
+```json
+{
+  "command": "doctor",
+  "ok": false,
+  "summary": { "total": 7, "passed": 4, "warned": 1, "failed": 2 },
+  "result": {
+    "checks": [
+      {
+        "name": "store.reachable",
+        "status": "fail",
+        "message": "cannot open badger store at ./conduit.db",
+        "suggestion": "Check the directory exists and is writable, or set db.badger.path.",
+        "code": "common.unavailable",
+        "configPath": "db.badger.path",
+        "category": "store"
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+Each check result carries a `status` of `pass`, `warn`, or `fail`, and failures
+carry a stable `code`, the failing `configPath`, and a `suggestion` — the same
+fields the [structured error model](/docs/using/other-features/structured-errors)
+uses everywhere. This is the same check set the MCP `doctor` tool wraps, so an
+agent and the CLI see identical results.
+
+## Using it in scripts and CI
+
+Because the exit codes are stable, `doctor` slots into a startup gate or a
+container entrypoint:
+
+```shell
+if ! conduit doctor --require-server=false --quiet; then
+  echo "environment not ready for conduit run" >&2
+  exit 1
+fi
+conduit run
+```
+
+Or branch on the failure kind, mirroring
+[exit-code scripting](/docs/using/other-features/exit-codes):
+
+```shell
+conduit doctor --json > doctor.json
+case $? in
+  0) echo "ready" ;;
+  2) echo "fix your configuration" ;;
+  3) echo "a dependency is unreachable" ;;
+esac
+```
+
+![scarf pixel conduit-site-docs-using-other-features](https://static.scarf.sh/a.png?x-pxid=8c8ff6d5-2756-41a3-b4ca-3ca2be381842)


### PR DESCRIPTION
## What

Documents Conduit's pre-deploy safety commands for the v0.17 CLI-as-product surface (roadmap §3 "CLI as product").

### Pages

- **`docs/1-using/4-pipelines/4-validate-lint-dry-run.mdx`** — "Validate, lint & dry-run." The offline safety loop (`validate` → `lint` → `dry-run` → `deploy`) plus the online `inspect` verb. Per-command sections with exact flags, exit codes, rendered output, and the shared `--json` envelope.
- **`docs/1-using/7-other-features/11-doctor.mdx`** — "`conduit doctor`." The offline preflight check set (config/store/network/plugins/engine), `--json` output, exit codes, and CI/scripting usage.

## Grounding

Every command, flag, exit code, and JSON shape was verified against source in `ConduitIO/conduit`:

- `cmd/conduit/root/pipelines/{validate,lint,dry_run,inspect}.go` (Docs strings + flag structs)
- `cmd/conduit/root/doctor/doctor.go`, `doctorcheck/`, `render.go`, and `pkg/conduit/check`
- Design docs: `20260707-cli-pipeline-validate.md`, `20260708-cli-pipeline-inspect-lint-dryrun.md`, `20260707-cli-doctor.md`

Conventions matched against `docs/1-using/2-cli.mdx`, the existing pipelines/other-features pages, and `9-exit-codes.mdx` / `10-structured-errors.mdx` (frontmatter, tone, cross-links, scarf pixel).

## Notes on accuracy

- `dry-run`'s plugin-resolution flag is documented as `--resolve-plugins` (the shipped name), not the design doc's earlier `--check-plugins`.
- `inspect` is documented as it actually ships: live status, name, error, per-stage source/destination rows, and DLQ. The design-doc mockup's `--records N` sample and per-stage record counts/uptime/lag are a tracked follow-up and are **not** documented as present.
- doctor `--json` summary is `{total, passed, warned, failed}` (the shipped `check.Summary`), not the design doc's earlier `{pass, warn, fail}`.

## Verification

`npm run build` passes (exit 0). No broken links introduced; the broken-*anchor* warnings in the build are all on pre-existing pages linking to `/api#...` and are unrelated to these pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD