### PR TITLE
docs: dev hot-reload loop + pipelines repair (0.17)

### DIFF
--- a/docs/1-using/4-pipelines/3-repair.mdx
+++ b/docs/1-using/4-pipelines/3-repair.mdx
@@ -1,0 +1,183 @@
+---
+title: 'Repairing a pipeline config'
+---
+
+`conduit pipelines repair` reads a pipeline configuration file, collects the
+validation findings that have a known machine-appliable fix, and — with
+`--apply` — writes those fixes back to the file. It is the applier half of
+Conduit's "errors are actionable" promise: the same structured fix a human sees
+in a diff is the one an agent applies over MCP.
+
+:::warning
+
+`repair` edits a **config file**. It never touches the pipeline store, a running
+pipeline, positions, checkpoints, or the DLQ. Getting a repaired file into a
+running engine is still
+[`deploy` / `apply`](/docs/using/pipelines/provisioning)'s job, with its own
+plan-hash and running-pipeline guards. If your problem is a **degraded running
+pipeline**, repairing a file won't restart it — fix the cause in config, then
+re-`apply` or restart the pipeline. See the note at the end of this page.
+
+:::
+
+## Preview the fixes
+
+Run `repair` with just a file to see what it would change. This mutates nothing:
+
+```shell
+conduit pipelines repair orders.yaml
+```
+
+Output lists each proposed fix — the finding it clears, the config path it
+touches, a before/after snippet, and a safety class — followed by a plan hash:
+
+```text
+Proposed fixes for "orders.yaml" (hash 9f3a2c...):
+
+  [safe]    /pipelines/0/status
+            - status: Running
+            + status: running
+
+  [restart] /pipelines/0/connectors/1/processors/0/workers
+            - workers: -1
+            + workers: 1
+
+Run:  conduit pipelines repair orders.yaml --apply --plan-hash 9f3a2c...
+```
+
+Add `--json` to get one structured object instead, for tooling.
+
+## Apply the fixes
+
+`--apply` writes the fixes to the file. It requires either the `--plan-hash`
+from the preview (so you apply exactly what you saw) or `--yes` to bind to a
+freshly recomputed plan:
+
+```shell
+conduit pipelines repair orders.yaml --apply --plan-hash 9f3a2c...
+# or, skip the preview and apply the current safe fixes directly:
+conduit pipelines repair orders.yaml --apply --yes
+```
+
+By default `--apply` writes **only the safe fixes**. Restart-class and
+data-path-adjacent fixes are never applied unless you select them explicitly:
+
+```shell
+# apply one specific fix by its config path
+conduit pipelines repair orders.yaml --apply --yes --fix /pipelines/0/connectors/1/processors/0/workers
+```
+
+The write is atomic (temp file + rename), so a crash mid-apply leaves the
+original file intact — never a half-written config. Comments and unrelated
+formatting are preserved; the applier edits the YAML nodes it targets and nothing
+else. After applying, `repair` re-validates the result: a fix that fails to clear
+its finding, or introduces a new one, fails the run rather than leaving the file
+worse.
+
+## Fix classes and the Tier-1 gate
+
+Every proposed fix is classified before it's offered, and the class controls
+whether it can be applied automatically:
+
+| Class | Meaning | Applied by default |
+| --- | --- | --- |
+| `safe` | Pipeline/processor metadata with no data-path effect | Yes |
+| `restart` | Would restart a running pipeline if deployed, but is not position/ack-adjacent | No — select with `--fix` |
+| `data_path` | Ack/position/checkpoint-adjacent config (connector settings, a connector's own plugin/type, DLQ, any `id`) | No — requires `--escalate` |
+
+Classification is default-deny: an unclassifiable config path is treated as
+`data_path` and refused, never assumed safe.
+
+A `data_path` fix requires the human-only `--escalate` flag **and** an explicit
+`--fix` selection:
+
+```shell
+conduit pipelines repair orders.yaml --apply --yes --fix /pipelines/0/connectors/0/settings/table --escalate
+```
+
+There is deliberately no equivalent of `--escalate` for agents over MCP (see
+[MCP](#repairing-over-mcp)) — that is what keeps the data-path Tier-1 sign-off
+real rather than theater.
+
+## What gets a fix (and what doesn't)
+
+A finding ships a fix only when its value is **deterministic** — no human
+judgement, no guessed name — and its config path is not data-path-adjacent. That
+rule keeps the set small and honest.
+
+Fixes available today:
+
+| Finding | Fix | Class |
+| --- | --- | --- |
+| Deprecated / renamed field | Rename the old key to its canonical name (semantics-preserving) | `safe` |
+| Invalid `/status` value that unambiguously maps (e.g. `Running` → `running`) | Set the canonical enum value | `safe` |
+| Negative processor `/workers` | Set to `1` (the ordering-preserving default) | `restart` |
+| `/description` over the length limit | Truncate to the limit (shown in the diff, never silent) | `safe` |
+
+Findings that **don't** get a fix keep their human `Suggestion` and report "no
+machine-appliable fix" — honest, not broken. These include:
+
+- **Unknown connector plugin** — the correct name isn't mechanically knowable;
+  `repair` never fabricates a plugin name.
+- **Invalid connector `/type`** (source vs. destination) — a semantic choice, not
+  derivable from the file.
+- **Missing required `/plugin`, `/id`, or `/type`** — no deterministic value to
+  supply.
+- **Duplicate `id`** — a rename rekeys a connector's stored position, so it's
+  data-path-adjacent, not a safe auto-fix.
+- **Anything under connector `settings`** — data-path by construction.
+
+## Error codes
+
+`repair` uses stable codes so the failure is machine-actionable. All map to exit
+code `2`:
+
+| Code | Raised when |
+| --- | --- |
+| `repair.plan_stale` | `--plan-hash` no longer matches (the file changed since the preview); nothing is written |
+| `repair.fix_no_longer_applies` | A selected fix's target was already changed by hand |
+| `repair.data_path_fix_refused` | A `data_path` fix was selected without `--escalate` (or at all via MCP) |
+| `repair.ambiguous_fix` | Two candidate fixes target the same path and none was `--fix`-selected |
+| `repair.no_fixes_available` | `--apply` requested but the plan has no appliable fixes |
+
+Preview mode with no fixes is not an error — it exits `0` with an "already clean"
+summary.
+
+## Repairing over MCP
+
+`repair` mirrors the CLI over MCP so an agent works the same code path:
+
+- **`repair`** (always available, read-only) — takes config content, returns the
+  proposed fixes, classes, and hash. Mutates nothing.
+- **`repair_apply`** (registered only when the server runs with
+  `--allow-mutations`) — applies the **safe** fixes and returns the edited
+  content. It **never** applies a `data_path` fix (it's returned as `skipped`
+  with `repair.data_path_fix_refused`), and there is no field an agent can set to
+  force one. Data-path escalation is the human CLI's `--escalate`, only.
+
+## Note: repairing a config vs. recovering a degraded pipeline
+
+"Repair" means two different things that are worth separating:
+
+- **Repairing a config file** — this command. It clears validation findings in a
+  YAML file so it deploys cleanly. Safe by construction: the worst it can do is
+  write a config that `deploy` then refuses.
+- **Recovering a degraded running pipeline** — a pipeline that stopped with a
+  fatal error. There is no store-mutating "repair" for this: you fix the cause in
+  config and restart the pipeline (which resumes from its last committed
+  position). Conduit deliberately has no casual position-reset or state-clear
+  button, because those are the mutations where data loss lives. If the cause is
+  unfixable by restart (for example, a source position that's no longer servable
+  after retention expired), recovery means recreating the pipeline.
+
+## Related
+
+- [Provisioning](/docs/using/pipelines/provisioning) — deploying a repaired file
+  into the engine.
+- [Local dev with hot-reload](/docs/using/dev-hot-reload) — iterate on a pipeline
+  with live reload instead of editing and redeploying.
+- [Pipeline statuses](/docs/using/pipelines/statuses) — including `degraded`.
+- [Structured errors](/docs/using/other-features/structured-errors) — the
+  `code` / `configPath` / `suggestion` / `fix` shape `repair` consumes.
+
+![scarf pixel conduit-site-docs-using-pipelines-repair](https://static.scarf.sh/a.png?x-pxid=4f41012a-be75-4b82-8112-86a7cb40f98a)

--- a/docs/1-using/dev-hot-reload.mdx
+++ b/docs/1-using/dev-hot-reload.mdx
@@ -1,0 +1,166 @@
+---
+title: 'Local dev with hot-reload'
+sidebar_position: 4.5
+---
+
+`conduit run --dev` runs Conduit and watches your pipelines directory, applying
+config changes to the running engine on save. Editing a pipeline becomes an
+edit-save-see loop instead of stop, edit, restart, wait.
+
+Where it can, the dev watcher applies a change **in place** — the pipeline keeps
+running, the source never restarts, and positions stay continuous. Where it
+can't do so safely, it falls back to a graceful drain-and-restart. Either way you
+never stop and start Conduit by hand.
+
+:::note
+
+The live in-place engine landed in Conduit v0.17. On older versions a config
+change to a running pipeline required a full restart. This page describes the
+current behavior: a processor edit is swapped into the running pipeline without a
+restart.
+
+:::
+
+## Start the dev watcher
+
+Point Conduit at a pipelines directory (or a single file) and add `--dev`:
+
+```shell
+conduit run --dev --pipelines.path ./pipelines
+```
+
+`--dev` is the short alias for `--dev.enabled`. With no `--pipelines.path` it
+watches the default `./pipelines` directory.
+
+There is also a thin alias that reads a little more naturally and takes the
+directory as a positional argument:
+
+```shell
+conduit pipelines dev ./pipelines
+```
+
+`conduit pipelines dev` runs exactly like `conduit run --dev`, with one
+dev-tuned default: exit-on-degraded is forced off, so one broken pipeline while
+you iterate doesn't take the whole dev server down. It carries no logic of its
+own.
+
+Startup is unchanged from `conduit run`: existing pipelines are provisioned and
+started normally, and only then does the watcher begin handling edits. An empty
+pipelines directory is fine — creating the first file live works.
+
+## What happens on each save
+
+1. **Debounce.** A save-storm (many rapid writes) coalesces into a single apply.
+2. **Parse and validate.** Every pipeline in the changed file goes through the
+   same enrich + validate the CLI uses. A syntax or validation error is printed
+   and the running pipeline is left untouched.
+3. **Diff and apply.** For each pipeline, the watcher computes the change and
+   applies it either in place or via a graceful restart (see below).
+4. **Ensure running.** After a successful apply, a pipeline the config wants
+   running but that is stopped — a brand-new file, or one left stopped by a
+   prior failed apply — is started. A pipeline the config declares `stopped` is
+   left stopped.
+
+Each apply prints whether it was in-place or a restart, the diff, the outcome,
+and timing. Add `--dev.json` to emit the same information as structured JSON
+event lines instead of human-readable text.
+
+## What reloads live vs. what forces a restart
+
+The split is drawn along a data-safety line, not a convenience one. A processor
+node holds no source position, no ack/durability state, and no external
+connection, so it can be swapped at a clean record boundary without risk. A
+source, destination, or DLQ owns position, ack, and connection state whose live
+mutation is genuinely dangerous — those changes drain and restart the pipeline
+instead.
+
+| Change | How it applies |
+| --- | --- |
+| A **processor's** config (settings, ordering within a processor) | **In place** — no restart |
+| A pipeline's **name** or **description** | **In place** — no restart |
+| A **source** or **destination** connector setting | Graceful drain-and-restart |
+| **DLQ** configuration | Graceful drain-and-restart |
+| **Topology** — add/remove a connector or processor, change a plugin, delete a pipeline | Graceful drain-and-restart |
+
+A single save that touches both a processor and a connector restarts the whole
+pipeline: the connector change needs a restart anyway, so the apply is
+all-or-nothing rather than half-swapped.
+
+### In-place processor swap: the guarantees
+
+When a processor edit applies in place, the engine builds and opens the **new**
+processor before tearing down the old one, and switches only at a record
+boundary between loop iterations:
+
+- **No records are lost or reordered.** Records already forwarded went through
+  the old config; records pulled after the switch go through the new one.
+  Ordering within a partition key is preserved.
+- **The source never rewinds.** A processor swap never touches the source
+  position. During the swap, backpressure pauses the source; it resumes exactly
+  where it paused.
+- **A bad edit never drops the pipeline.** If the new processor config fails to
+  open (bad settings, a broken WASM processor), the old processor keeps running,
+  the new one is discarded, and the error is printed.
+
+The one exposure is a `kill -9` mid-swap: in-flight records since the last
+checkpoint are reprocessed on restart (the at-least-once floor) — possible
+duplicates, never drops. The stored config is the source of truth, so a restart
+always rebuilds from either the old or new config, never a torn half.
+
+:::note
+
+In-place swap is currently limited to the non-buffering processor model Conduit
+ships today (one batch in, results out, nothing held across calls). A future
+batching or windowing processor that retains records internally would be
+restart-class until it grows a flush-before-teardown step.
+
+:::
+
+## Authorization
+
+Applying a change to a running pipeline normally requires the process-level
+`--api.allow-live-restart-apply` gate. `--dev` authorizes the applies **its own
+watcher drives from local file edits** — you ran `--dev`, you're watching the
+terminal, and you see every diff scroll by. That is the operator authorization
+the gate exists to require.
+
+`--dev` does **not** set `--api.allow-live-restart-apply`. A remote agent still
+can't apply changes to a running pipeline over the API or MCP unless that
+separate flag is set. This is the same trust boundary as startup provisioning:
+whoever can edit the watched files and run `--dev` on this box can already
+restart these pipelines.
+
+## Failure modes
+
+- **Syntax or validation error on save** — the error is printed with its code
+  and config path; the running pipeline keeps its last-good config. Fix and save
+  again.
+- **A new config fails at open or start** (e.g. an unreachable source) — the
+  pipeline is left stopped with the error; the next good save recovers it.
+- **A watched file is deleted** — the pipeline is left **running** and a message
+  is logged. `--dev` never deletes a running pipeline because a file vanished
+  (a `git stash`, say). Stop it explicitly if that was the intent.
+- **`Ctrl-C`** — the watcher is cancelled as part of graceful shutdown;
+  in-flight records drain and checkpoint before exit.
+
+## Notes
+
+- **Not a production deploy mechanism.** `--dev` is a foreground, single-author,
+  local convenience. For unattended or remote apply, use the API/MCP `apply`
+  path with its own operator gate.
+- **`--dev.json`** emits one JSON object per apply (mode, diff, outcome, timing)
+  for tooling; logs still go to stderr.
+- To get a repaired or edited config file into a running engine without `--dev`,
+  use [`conduit pipelines deploy` / `apply`](/docs/using/pipelines/provisioning),
+  which keep their own plan-hash and running-pipeline guards.
+
+## Related
+
+- [Provisioning](/docs/using/pipelines/provisioning) — how Conduit loads
+  pipeline files at startup (the non-dev default: no watching).
+- [Repairing a pipeline config](/docs/using/pipelines/repair) — clear
+  machine-appliable validation findings before you deploy.
+- [Pipeline statuses](/docs/using/pipelines/statuses) — running, degraded, and
+  the rest.
+
+![scarf pixel conduit-site-docs-using-dev-hot-reload](https://static.scarf.sh/a.png?x-pxid=4f41012a-be75-4b82-8112-86a7cb40f98a)


### PR DESCRIPTION
Two how-to pages for Conduit's developer/recovery workflow, verified against the engine source and design docs.

## Pages

- **`docs/1-using/dev-hot-reload.mdx` — Local dev with hot-reload.** The `conduit run --dev` (and `conduit pipelines dev [dir]` alias) edit-save-see loop. Documents the current live in-place engine (landed v0.17, #2613/#2617/#2619): a **processor config** or pipeline **name/description** change applies in place with no restart; a **connector / DLQ / topology** change applies via a graceful drain-and-restart. Covers the in-place processor-swap guarantees (open-before-teardown, boundary switch, backpressure, `kill -9` = duplicates-not-drops), the non-buffering-processor caveat, and the `--dev` authorization model (`--dev` authorizes local-file applies; it does **not** set `--api.allow-live-restart-apply`).
- **`docs/1-using/4-pipelines/3-repair.mdx` — Repairing a pipeline config.** `conduit pipelines repair <file>` preview/apply, **file-not-store** semantics (edits YAML, never the store or a running pipeline; atomic write; comments preserved), the `safe` / `restart` / `data_path` fix classes with the human-only `--escalate` gate, the v1 fix-synthesis set, stable error codes, and the MCP `repair` / `repair_apply` split. Explicitly separates config-file repair from recovering a **degraded running pipeline** (restart-after-fix; no casual position-reset), per the API-semantics design doc.

## Grounding

- `docs/design-documents/20260712-pipeline-dev-hot-reload.md`, `docs/operations/dev-hot-reload.md`
- `docs/design-documents/20260712-repair-command.md`, `docs/design-documents/20260715-pipeline-repair-api-semantics.md`
- Commands verified against `cmd/conduit/root/run/run.go`, `cmd/conduit/root/pipelines/dev.go`, and `cmd/conduit/root/pipelines/repair.go` (flag names, aliases, examples).

## Notes for review

- **Placement.** `dev-hot-reload.mdx` is a top-level `1-using` page slotted right after **Pipelines** via `sidebar_position: 4.5` rather than a numeric filename prefix — the sidebar is autogenerated and every top-level slot 0–8 is taken, so a prefix would have meant renumbering the `connectors`/`processors`/`other-features`/`guides` folders (100+ file moves). Slugs strip numeric prefixes, so ordering is the only thing at stake. Happy to switch to a renumber if you'd rather keep the prefix convention.
- Prettier is not enforced on docs MDX here (existing hand-authored pages don't pass `prettier --check` either); the new pages follow the established doc style.

Roadmap: Phase 1 (Developer Experience Core) — §3 verb parity, §4 hot-reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD