### PR TITLE
docs: 0.18 banner + changelog + fix stale conduit.io references

### DIFF
--- a/changelog/2026-07-23-conduit-0-18-0-release.mdx
+++ b/changelog/2026-07-23-conduit-0-18-0-release.mdx
@@ -1,0 +1,21 @@
+---
+slug: '2026-07-23-conduit-0-18-0-release'
+title: Conduit v0.18.0 release
+draft: false
+tags: [conduit, release, conduit-release]
+---
+
+[Conduit v0.18.0](https://github.com/ConduitIO/conduit/releases/tag/v0.18.0) is the "trust your connectors, see your pipelines" release: a signed connector registry you can install from the CLI with signatures and SLSA provenance verified before anything runs, and a built-in UI served by `conduit run` for watching and operating your pipelines.
+
+<!--truncate-->
+
+### Key Highlights
+
+- **Signed connector registry.** `conduit connectors install <name>` fetches a connector from the registry, verifies its signature **and** its SLSA provenance, and refuses anything it can't verify — no manual downloads, no unsigned binaries. Every connector is cosign-signed keyless (there are no private keys to leak) with SLSA Level 3 build provenance, pinned to the publisher's own release workflow, so you know a connector was built by who it claims, from the source it claims. Verification is fail-closed by design.
+- **Manage what's installed.** `conduit connectors uninstall`, `list --installed`, `audit` (re-verify every installed connector against the current index), and `bundle` (package a connector for air-gapped installs) round out the lifecycle.
+- **Publish your own connector.** Drop the [connector-publish-action](https://github.com/ConduitIO/connector-publish-action) workflow into your connector repo and a tagged release is signed, provenance-attested, and proposed to the registry automatically.
+- **Built-in UI.** `conduit run` now serves a UI at `/` — nothing extra to install. Watch the live record flow with per-stage before/after diffs, see pipeline topology, throughput, latency, and health at a glance, and start or stop pipelines from the browser. Authoring stays config-as-code; the UI is for observing and operating.
+
+The registry launches with signed seed connectors for [Postgres](https://github.com/ConduitIO/conduit-connector-postgres), [Kafka](https://github.com/ConduitIO/conduit-connector-kafka), [file](https://github.com/ConduitIO/conduit-connector-file), [generator](https://github.com/ConduitIO/conduit-connector-generator), and [log](https://github.com/ConduitIO/conduit-connector-log) — with [S3](https://github.com/ConduitIO/conduit-connector-s3) and more to follow.
+
+![scarf pixel conduit-site-changelog](https://static.scarf.sh/a.png?x-pxid=b43cda70-9a98-4938-8857-471cc05e99c5)

--- a/docs/1-using/2-cli.mdx
+++ b/docs/1-using/2-cli.mdx
@@ -48,7 +48,7 @@ This page is the exhaustive command reference. For narrower how-tos, see:
 | `conduit quickstart` | | — | Run an ephemeral demo pipeline, no config needed |
 | `conduit doctor` | | offline (optional) | Preflight checks: would `conduit run` succeed here? |
 | `conduit mcp` | | — | Run Conduit's MCP server for AI agents |
-| `conduit open docs` | `docs` | offline | Open conduit.io docs in a browser |
+| `conduit open docs` | `docs` | offline | Open the Conduit documentation in a browser |
 | `conduit config` | | offline | Show the resolved configuration |
 | `conduit version` | | offline | Print the Conduit version |
 | `conduit pipelines list` | `ls` | yes | List registered pipelines |
@@ -203,7 +203,7 @@ and hardening reference.
 
 ### `conduit open docs` (alias: `conduit docs`)
 
-Opens the conduit.io documentation in your default web browser.
+Opens the Conduit documentation (conduitdata.io) in your default web browser.
 
 ```shell
 conduit open docs

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
     },
     announcementBar: {
       id: 'announcement-bar-17-0', // increment on change
-      content: `Conduit v0.17.0 is here! <a class='cta' href='/changelog/2026-07-13-conduit-0-17-0-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
+      content: `Conduit v0.18.0 is here! <a class='cta' href='/changelog/2026-07-23-conduit-0-18-0-release' target='_blank' rel='noreferrer noopener'>See what's new</a>.`,
       isCloseable: true,
     },
     colorMode: {


### PR DESCRIPTION
- Announcement banner → **v0.18.0**, linking a new 0.18 changelog post
- New `changelog/2026-07-23-conduit-0-18-0-release.mdx` (signed registry + built-in UI; 5 seed connectors, S3 fast-follow)
- Fixed the two hand-written `conduit.io` references in the CLI reference → conduitdata.io (generated content is already rewritten by `connectorgen/domain.go`)

`npm run build` passes (onBrokenLinks: throw → banner link resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)